### PR TITLE
Add infer_data_spec field to TemplateBuilderViewSpec

### DIFF
--- a/src/client/project/view_spec.py
+++ b/src/client/project/view_spec.py
@@ -122,6 +122,14 @@ class TemplateBuilderViewSpec(ViewSpec, spec_value=ViewSpec.TEMPLATE_BUILDER):
         plugins:
         vars:
         core_version: Default template components version. Most users will not need to change this parameter.
+        infer_data_spec: You can configure the data specification automatically or manually. You can change the way the
+            specification is configured using the infer_data_spec option:
+            * True – The specifications of input and output data are generated automatically depending on the task interface settings.
+            * False – You can configure the specification manually. In this case, automatic detection of input and output data doesn't work.
+                You may need to enable this option if:
+                * You don't want the specification version to be affected by changes in the instructions or other project fields.
+                * You have fields that you need but they become optional or are deleted after automatic generation.
+
 
     Example:
         How to declare simple interface:
@@ -140,6 +148,7 @@ class TemplateBuilderViewSpec(ViewSpec, spec_value=ViewSpec.TEMPLATE_BUILDER):
 
     config: TemplateBuilder
     core_version: str = '1.0.0'
+    infer_data_spec: bool = attribute(origin='inferDataSpec')
 
     def unstructure(self):
         data = super().unstructure()

--- a/tests/template_builder/conftest.py
+++ b/tests/template_builder/conftest.py
@@ -29,6 +29,7 @@ EXAMPLES = [
             "showTimer": True,
             "showTitle": True
         },
+        "infer_data_spec": True,
         "type": "tb",
         "assets": {
             "script_urls": [
@@ -69,6 +70,7 @@ EXAMPLES = [
             "showTimer": True,
             "showTitle": True
         },
+        "infer_data_spec": False,
         "type": "tb",
         "assets": {
             "script_urls": [


### PR DESCRIPTION
There is a new feature in API which allows you to control whether data spec will be generated automatically based on template builder config or it will be provided manually.