### PR TITLE
Add user-metadata endpoint support

### DIFF
--- a/docs/reference/toc.yaml
+++ b/docs/reference/toc.yaml
@@ -277,6 +277,8 @@ items:
         href: toloka.client.TolokaClient.get_user_skill.md
       - name: get_user_skills
         href: toloka.client.TolokaClient.get_user_skills.md
+      - name: get_user
+        href: toloka.client.TolokaClient.get_user.md
       - name: set_user_skill
         href: toloka.client.TolokaClient.set_user_skill.md
     - name: webhook subscription
@@ -1885,6 +1887,13 @@ items:
       hidden: true
     - name: codegen_setter_for_owner
       href: toloka.client.training.codegen_setter_for_owner.md
+      hidden: true
+  - name: user
+    items:
+    - name: User
+      href: toloka.client.user.User.md
+    - name: User.Attributes
+      href: toloka.client.user.User.Attributes.md
       hidden: true
   - name: user_bonus
     items:

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -58,6 +58,7 @@ __all__ = [
     'UserBonusCreateRequestParameters',
     'UserRestriction',
     'UserSkill',
+    'User',
     'Pool',
     'PoolPatchRequest',
     'Project',
@@ -153,6 +154,7 @@ from .task_suite import TaskSuite
 from .user_bonus import UserBonus, UserBonusCreateRequestParameters
 from .user_restriction import UserRestriction
 from .user_skill import SetUserSkillRequest, UserSkill
+from .user import User
 from ..util import identity
 from ..util._managing_headers import add_headers, form_additional_headers
 from ..util._codegen import expand
@@ -3117,6 +3119,20 @@ class TolokaClient:
         generator = self._find_all(self.find_user_skills, request)
         generator.send(None)
         return generator
+
+    @add_headers('client')
+    def get_user(self, user_id: str) -> User:
+        """Gets Toloker metadata by user_id.
+
+        Args:
+            user_id: Toloker ID.
+
+        Returns:
+            User: Contains Toloker metadata.
+        """
+
+        response = self._request('get', f'/v1/user-metadata/{user_id}')
+        return structure(response, User)
 
     @expand('request')
     @add_headers('client')

--- a/src/client/user.py
+++ b/src/client/user.py
@@ -1,0 +1,37 @@
+__all__ = [
+    'User',
+]
+
+from typing import List
+
+from .primitives.base import BaseTolokaObject
+
+
+class User(BaseTolokaObject):
+    """Toloker metadata.
+
+    Attributes:
+        id: Toloker ID.
+        country: Toloker country code.
+        languages: list of languages that Toloker know represented with language codes.
+        adult_allowed: shows whether Toloker agreed to complete tasks with adult content.
+        attributes: Toloker attributes.
+    """
+
+    class Attributes(BaseTolokaObject):
+        country_by_phone: str
+        country_by_ip: str
+        client_type: str
+        user_agent_type: str
+        device_category: str
+        os_family: str
+        os_version: float
+        os_version_major: int
+        os_version_minor: int
+        os_version_bugfix: int
+
+    id: str
+    country: str
+    languages: List[str]
+    adult_allowed: bool
+    attributes: Attributes

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,41 @@
+import pytest
+import toloka.client as client
+from .testutils.util_functions import check_headers
+
+
+@pytest.fixture
+def user_map():
+    return {
+        "id": "123",
+        "country": "EN",
+        "languages": ["EN"],
+        "adult_allowed": True,
+        "attributes": {
+            "country_by_phone": "EN",
+            "country_by_ip": "EN",
+            "client_type": "TOLOKA_APP",
+            "user_agent_type": "OTHER",
+            "device_category": "SMARTPHONE",
+            "os_family": "ANDROID",
+            "os_version": 6.0,
+            "os_version_major": 6,
+            "os_version_minor": 0,
+            "os_version_bugfix": 1,
+        },
+    }
+
+
+def test_get_user(requests_mock, toloka_client, toloka_url, user_map):
+    def get_user(request, context):
+        expected_headers = {
+            "X-Caller-Context": "client",
+            "X-Top-Level-Method": "get_user",
+            "X-Low-Level-Method": "get_user",
+        }
+        check_headers(request, expected_headers)
+
+        return user_map
+
+    requests_mock.get(f"{toloka_url}/user-metadata/123", json=get_user)
+    result = toloka_client.get_user("123")
+    assert user_map == client.unstructure(result)


### PR DESCRIPTION
Supported GET user-metadata endpoint which returns Toloker metadata by their ID.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
