### PR TITLE
Add python-sdk.md file on PR to docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -28,7 +28,10 @@ jobs:
     - name: Generate markdowns
       run: |
         python ./misc/stubmaker/bin/make_markdowns $(./misc/stubmaker/bin/make_markdowns/tolokakit_args.sh) --github-source-url https://github.com/Toloka/toloka-kit/blob/${{ github.event.release.tag_name }}/src
+        mv docs-repo/en/toloka-kit/python-sdk.md .
         rm -r docs-repo/en/toloka-kit
+        mkdir docs-repo/en/toloka-kit
+        mv python-sdk.md docs-repo/en/toloka-kit
         python misc/add_python_sdk_to_toc.py --path docs/toc.yaml
         mv docs docs-repo/en/toloka-kit
     - name: Create Pull Request to docs repository

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -19,6 +19,7 @@ jobs:
         pip install https://github.com/Toloka/stubmaker/archive/refs/heads/main.zip
         pip install .[all]
         pip install "attrs>=21.0.0"
+        pip install pyyaml
     - name: Checkout docs repository
       uses: actions/checkout@v3
       with:
@@ -28,6 +29,7 @@ jobs:
       run: |
         python ./misc/stubmaker/bin/make_markdowns $(./misc/stubmaker/bin/make_markdowns/tolokakit_args.sh) --github-source-url https://github.com/Toloka/toloka-kit/blob/${{ github.event.release.tag_name }}/src
         rm -r docs-repo/en/toloka-kit
+        python misc/add_python_sdk_to_toc.py --path docs/toc.yaml
         mv docs docs-repo/en/toloka-kit
     - name: Create Pull Request to docs repository
       uses: peter-evans/create-pull-request@v4

--- a/misc/add_python_sdk_to_toc.py
+++ b/misc/add_python_sdk_to_toc.py
@@ -1,0 +1,26 @@
+# pyyaml is required
+
+import argparse
+import yaml
+from pathlib import Path
+
+
+class IndentListDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", type=Path)
+    args = parser.parse_args()
+    with open(args.path) as f:
+        parsed = yaml.load(f, Loader=yaml.SafeLoader)
+        parsed["items"].append(
+            {"name": "Python SDK", "href": "python-sdk.md", "hidden": True}
+        )
+    with open(args.path, "w") as f:
+        content = yaml.dump(
+            parsed, default_flow_style=False, sort_keys=False, Dumper=IndentListDumper
+        )
+        f.write(content)

--- a/misc/stubmaker/src/tk_stubgen/util.py
+++ b/misc/stubmaker/src/tk_stubgen/util.py
@@ -21,7 +21,10 @@ class GitHubSourceFinder:
 
         file_path = '/'.join(definition_module_name.split('.')[1:]) + '.py'
         try:
-            line = findsource(definition.obj)[1]
+            obj = definition.obj
+            while hasattr(obj, '__wrapped__'):
+                obj = obj.__wrapped__
+            line = findsource(obj)[1]
         except OSError as exc:
             msg = f"Can't find source for {definition.obj}"
             if self.handle_unknown_source == 'ignore':


### PR DESCRIPTION
Toloka/docs repository stores python-sdk.md file in docs directory. It is unwanted to also have it in this repository's docs. The solution is to add this file to docs/toc.yaml in the GitHub action.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
