### PR TITLE
Introduce upper bound on cattrs version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     python_requires='>=3.7.0',
     install_requires=[
         'attrs >= 20.3.0',
-        'cattrs >= 1.1.1',
+        'cattrs >= 1.1.1, < 22.2.0',
         'cached-property; python_version < "3.8.0"',
         'filelock >= 3.2.0',
         'requests',


### PR DESCRIPTION
22.2.0 breaks test_operator.py tests. Hard bounded the version of the dependency for the time being.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
