### PR TITLE
Specify content type when manually serializing JSON

### DIFF
--- a/functional_tests/template_builder/test_completeness.py
+++ b/functional_tests/template_builder/test_completeness.py
@@ -22,6 +22,7 @@ UNDOCUMENTED_COMPONENTS = {
     'field.multi-select',
     'helper.length',
     'helper.sum',
+    'helper.multiply',
     'view.debug',
     'view.hint',
     'view.json',

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -364,6 +364,7 @@ class TolokaClient:
         json_param = prepared_kwargs.pop('json', None)
         if json_param:
             prepared_kwargs['content'] = simplejson.dumps(json_param)
+            headers['Content-Type'] = 'application/json'
         return prepared_kwargs
 
     def _raw_request(self, method, path, **kwargs):

--- a/src/client/filter.py
+++ b/src/client/filter.py
@@ -382,6 +382,7 @@ class Languages(Profile, InclusionConditionMixin, spec_value=Profile.Key.LANGUAG
         'ES': '32346',
         'FR': '26711',
         'HE': '44954',
+        'HU': '54378',
         'ID': '39821',
         'JA': '26513',
         'PT': '26714',


### PR DESCRIPTION
Fixed a bug, when JSON request content type was specified incorrectly. Updated integrational tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
