### PR TITLE
Add batch size for each get items operation

### DIFF
--- a/src/async_client/client.py
+++ b/src/async_client/client.py
@@ -8,6 +8,7 @@ import functools
 import logging
 import threading
 from decimal import Decimal
+from typing import Optional
 
 import attr
 import httpx
@@ -91,7 +92,8 @@ class AsyncTolokaClient:
     async def _request(self, method, path, **kwargs):
         return (await self._raw_request(method, path, **kwargs)).json(parse_float=Decimal)
 
-    async def _find_all(self, find_function, request, sort_field: str = 'id', items_field: str = 'items'):
+    async def _find_all(self, find_function, request, sort_field: str = 'id',
+                        items_field: str = 'items', batch_size: Optional[int] = None):
         result = await find_function(request, sort=[sort_field])
         items = getattr(result, items_field)
         while result.has_more:

--- a/src/async_client/client.py
+++ b/src/async_client/client.py
@@ -94,7 +94,7 @@ class AsyncTolokaClient:
 
     async def _find_all(self, find_function, request, sort_field: str = 'id',
                         items_field: str = 'items', batch_size: Optional[int] = None):
-        result = await find_function(request, sort=[sort_field])
+        result = await find_function(request, sort=[sort_field], limit=batch_size)
         items = getattr(result, items_field)
         while result.has_more:
             request = attr.evolve(request, **{f'{sort_field}_gt': getattr(items[-1], sort_field)})

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -389,7 +389,7 @@ class TolokaClient:
         while result.has_more:
             request = attr.evolve(request, **{f'{sort_field}_gt': getattr(items[-1], sort_field)})
             yield from items
-            result = find_function(request, sort=[sort_field])
+            result = find_function(request, sort=[sort_field], limit=batch_size)
             items = getattr(result, items_field)
 
         yield from items
@@ -2623,7 +2623,7 @@ class TolokaClient:
     @expand('request')
     @add_headers('client')
     def get_task_suites(
-        self, 
+        self,
         request: search_requests.TaskSuiteSearchRequest,
         batch_size: Optional[int] = None
     ) -> Generator[TaskSuite, None, None]:
@@ -2811,7 +2811,7 @@ class TolokaClient:
     @expand('request')
     @add_headers('client')
     def get_operations(
-        self, 
+        self,
         request: search_requests.OperationSearchRequest,
         batch_size: Optional[int] = None
     ) -> Generator[operations.Operation, None, None]:
@@ -3061,7 +3061,7 @@ class TolokaClient:
     @expand('request')
     @add_headers('client')
     def get_user_bonuses(
-        self, 
+        self,
         request: search_requests.UserBonusSearchRequest,
         batch_size: Optional[int] = None
     ) -> Generator[UserBonus, None, None]:

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -383,8 +383,8 @@ class TolokaClient:
             params['limit'] = limit
         return self._request(method, path, params=params)
 
-    def _find_all(self, find_function, request, sort_field: str = 'id', items_field: str = 'items'):
-        result = find_function(request, sort=[sort_field])
+    def _find_all(self, find_function, request, sort_field: str = 'id', items_field: str = 'items', batch_size: Optional[int] = None):
+        result = find_function(request, sort=[sort_field], limit=batch_size)
         items = getattr(result, items_field)
         while result.has_more:
             request = attr.evolve(request, **{f'{sort_field}_gt': getattr(items[-1], sort_field)})
@@ -575,7 +575,8 @@ class TolokaClient:
     @add_headers('client')
     def get_aggregated_solutions(
         self,
-        operation_id: str, request: search_requests.AggregatedSolutionSearchRequest
+        operation_id: str, request: search_requests.AggregatedSolutionSearchRequest,
+        batch_size: Optional[int] = None
     ) -> Generator[AggregatedSolution, None, None]:
         """Finds all aggregated responses that match certain criteria.
 
@@ -594,6 +595,7 @@ class TolokaClient:
         Args:
             operation_id: The ID of the aggregation operation.
             request: Search criteria.
+            batch_size: Returned aggregated responses limit for each request. The default batch_size is 50. The maximum allowed limit is 100,000.
 
         Yields:
             AggregatedSolution: The next matching aggregated response.
@@ -612,7 +614,7 @@ class TolokaClient:
             ...
         """
         find_function = functools.partial(self.find_aggregated_solutions, operation_id)
-        generator = self._find_all(find_function, request, sort_field='task_id')
+        generator = self._find_all(find_function, request, sort_field='task_id', batch_size=batch_size)
         yield from generator
 
     # Assignments section
@@ -684,7 +686,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_assignments(self, request: search_requests.AssignmentSearchRequest) -> Generator[Assignment, None, None]:
+    def get_assignments(
+        self,
+        request: search_requests.AssignmentSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Assignment, None, None]:
         """Finds all assignments that match certain criteria.
 
         `get_assignments` returns a generator. You can iterate over all found assignments using the generator. Several requests to the Toloka server are possible while iterating.
@@ -693,6 +699,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned assignments limit for each request. The default batch_size  is 50. The maximum allowed batch_size  is 100,000.
 
         Yields:
             Assignment: The next matching assignment.
@@ -705,7 +712,7 @@ class TolokaClient:
             >>> result_list = [assignment.id for assignment in assignments]
             ...
         """
-        generator = self._find_all(self.find_assignments, request)
+        generator = self._find_all(self.find_assignments, request, batch_size=batch_size)
         yield from generator
 
     @expand('patch')
@@ -802,7 +809,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_attachments(self, request: search_requests.AttachmentSearchRequest) -> Generator[Attachment, None, None]:
+    def get_attachments(
+        self,
+        request: search_requests.AttachmentSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Attachment, None, None]:
         """Finds all attachments that match certain criteria and returns their metadata.
 
         `get_attachments` returns a generator. You can iterate over all found attachments using the generator. Several requests to the Toloka server are possible while iterating.
@@ -811,6 +822,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned attachments limit for each request. The maximum allowed batch_size is 100.
 
         Yields:
             Attachment: The next matching attachment.
@@ -821,7 +833,7 @@ class TolokaClient:
             >>> results_list = list(toloka_client.get_attachments(pool_id='1'))
             ...
         """
-        generator = self._find_all(self.find_attachments, request)
+        generator = self._find_all(self.find_attachments, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -951,7 +963,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_message_threads(self, request: search_requests.MessageThreadSearchRequest) -> Generator[MessageThread, None, None]:
+    def get_message_threads(
+        self,
+        request: search_requests.MessageThreadSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[MessageThread, None, None]:
         """Finds all message threads that match certain criteria.
 
         `get_message_threads` returns a generator. You can iterate over all found message threads using the generator. Several requests to the Toloka server are possible while iterating.
@@ -960,6 +976,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned message threads limit for each request. The default batch_size is 50. The maximum allowed batch_size is 300.
 
         Yields:
             MessageThread: The next matching message thread.
@@ -970,7 +987,7 @@ class TolokaClient:
             >>> message_threads = toloka_client.get_message_threads(folder=['INBOX', 'UNREAD'])
             ...
         """
-        generator = self._find_all(self.find_message_threads, request)
+        generator = self._find_all(self.find_message_threads, request, batch_size=batch_size)
         yield from generator
 
     @autocast_to_enum
@@ -1122,7 +1139,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_projects(self, request: search_requests.ProjectSearchRequest) -> Generator[Project, None, None]:
+    def get_projects(
+        self,
+        request: search_requests.ProjectSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Project, None, None]:
         """Finds all projects that match certain criteria.
 
         `get_projects` returns a generator. You can iterate over all found projects using the generator. Several requests to the Toloka server are possible while iterating.
@@ -1131,6 +1152,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned projects limit for each request. The default batch_size is 20. The maximum allowed batch_size is 300.
 
         Yields:
             Project: The next matching project.
@@ -1145,7 +1167,7 @@ class TolokaClient:
             >>> my_projects = toloka_client.get_projects()
             ...
         """
-        generator = self._find_all(self.find_projects, request)
+        generator = self._find_all(self.find_projects, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -1537,7 +1559,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_pools(self, request: search_requests.PoolSearchRequest) -> Generator[Pool, None, None]:
+    def get_pools(
+        self,
+        request: search_requests.PoolSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Pool, None, None]:
         """Finds all pools that match certain criteria.
 
         `get_pools` returns a generator. You can iterate over all found pools using the generator. Several requests to the Toloka server are possible while iterating.
@@ -1546,6 +1572,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned pools limit for each request. The default batch_size is 20. The maximum allowed batch_size is 300.
 
         Yields:
             Pool: The next matching pool.
@@ -1561,7 +1588,7 @@ class TolokaClient:
             >>> all_pools = toloka_client.get_pools(project_id='1')
             ...
         """
-        generator = self._find_all(self.find_pools, request)
+        generator = self._find_all(self.find_pools, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -1904,7 +1931,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_trainings(self, request: search_requests.TrainingSearchRequest) -> Generator[Training, None, None]:
+    def get_trainings(
+        self,
+        request: search_requests.TrainingSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Training, None, None]:
         """Finds all trainings that match certain criteria.
 
         `get_trainings` returns a generator. You can iterate over all found trainings using the generator. Several requests to the Toloka server are possible while iterating.
@@ -1913,6 +1944,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned trainings limit for each request. The maximum allowed batch_size is 300.
 
         Yields:
             Training: The next matching training.
@@ -1923,7 +1955,7 @@ class TolokaClient:
             >>> trainings = toloka_client.get_trainings(project_id='1')
             ...
         """
-        generator = self._find_all(self.find_trainings, request)
+        generator = self._find_all(self.find_trainings, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -2082,7 +2114,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_skills(self, request: search_requests.SkillSearchRequest) -> Generator[Skill, None, None]:
+    def get_skills(
+        self,
+        request: search_requests.SkillSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Skill, None, None]:
         """Finds all skills that match certain criteria.
 
         `get_skills` returns a generator. You can iterate over all found skills using the generator. Several requests to the Toloka server are possible while iterating.
@@ -2091,6 +2127,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned skills limit for each request. The maximum allowed batch_size is 100.
 
         Yields:
             Skill: The next matching skill.
@@ -2105,7 +2142,7 @@ class TolokaClient:
             >>>     print('Create new segmentation skill here')
             ...
         """
-        generator = self._find_all(self.find_skills, request)
+        generator = self._find_all(self.find_skills, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -2332,7 +2369,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_tasks(self, request: search_requests.TaskSearchRequest) -> Generator[Task, None, None]:
+    def get_tasks(
+        self,
+        request: search_requests.TaskSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[Task, None, None]:
         """Finds all tasks that match certain criteria.
 
         `get_tasks` returns a generator. You can iterate over all found tasks using the generator. Several requests to the Toloka server are possible while iterating.
@@ -2341,6 +2382,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned tasks limit for each request. The default batch_size is 50. The maximum allowed batch_size is 100,000.
 
         Yields:
             Task: The next matching task.
@@ -2351,7 +2393,7 @@ class TolokaClient:
             >>> results_list = list(toloka_client.get_tasks(pool_id='1'))
             ...
         """
-        generator = self._find_all(self.find_tasks, request)
+        generator = self._find_all(self.find_tasks, request, batch_size=batch_size)
         yield from generator
 
     @expand('patch')
@@ -2580,7 +2622,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_task_suites(self, request: search_requests.TaskSuiteSearchRequest) -> Generator[TaskSuite, None, None]:
+    def get_task_suites(
+        self, 
+        request: search_requests.TaskSuiteSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[TaskSuite, None, None]:
         """Finds all task suites that match certain criteria.
 
         `get_task_suites` returns a generator. You can iterate over all found task suites using the generator. Several requests to the Toloka server are possible while iterating.
@@ -2589,6 +2635,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned task suites limit for each request. The default batch_size is 50. The maximum allowed batch_size is 100,000.
 
         Yields:
             TaskSuite: The next matching task suite.
@@ -2599,7 +2646,7 @@ class TolokaClient:
             >>> results_list = list(toloka_client.get_task_suites(pool_id='1'))
             ...
         """
-        generator = self._find_all(self.find_task_suites, request)
+        generator = self._find_all(self.find_task_suites, request, batch_size=batch_size)
         yield from generator
 
     @expand('patch')
@@ -2763,7 +2810,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_operations(self, request: search_requests.OperationSearchRequest) -> Generator[operations.Operation, None, None]:
+    def get_operations(
+        self, 
+        request: search_requests.OperationSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[operations.Operation, None, None]:
         """Finds all operations that match certain rules and returns them in an iterable object
 
        `get_operations` returns a generator. You can iterate over all found operations using the generator. Several requests to the Toloka server are possible while iterating.
@@ -2772,6 +2823,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned operations limit for each request. The default batch_size is 50. The maximum allowed batch_size is 500.
 
         Yields:
             Operation: The next matching operations.
@@ -2780,7 +2832,7 @@ class TolokaClient:
             >>> bonuses = list(toloka_client.get_operations(submitted_lt='2021-06-01T00:00:00'))
             ...
         """
-        generator = self._find_all(self.find_operations, request)
+        generator = self._find_all(self.find_operations, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -3008,7 +3060,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_user_bonuses(self, request: search_requests.UserBonusSearchRequest) -> Generator[UserBonus, None, None]:
+    def get_user_bonuses(
+        self, 
+        request: search_requests.UserBonusSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[UserBonus, None, None]:
         """Finds all Tolokers' rewards that match certain rules and returns them in an iterable object
 
        `get_user_bonuses` returns a generator. You can iterate over all found Tolokers' rewards using the generator. Several requests to the Toloka server are possible while iterating.
@@ -3017,6 +3073,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned Tolokers' rewards limit for each request. The maximum allowed batch_size is 300.
 
         Yields:
             UserBonus: The next matching Toloker's reward.
@@ -3025,7 +3082,7 @@ class TolokaClient:
             >>> bonuses = list(toloka_client.get_user_bonuses(created_lt='2021-06-01T00:00:00'))
             ...
         """
-        generator = self._find_all(self.find_user_bonuses, request)
+        generator = self._find_all(self.find_user_bonuses, request, batch_size=batch_size)
         yield from generator
 
     # User restrictions
@@ -3080,7 +3137,8 @@ class TolokaClient:
     @add_headers('client')
     def get_user_restrictions(
         self,
-        request: search_requests.UserRestrictionSearchRequest
+        request: search_requests.UserRestrictionSearchRequest,
+        batch_size: Optional[int] = None
     ) -> Generator[UserRestriction, None, None]:
         """Finds all Toloker restrictions that match certain criteria.
 
@@ -3090,6 +3148,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned Toloker restrictions limit for each request. The maximum allowed batch_size is 500.
 
         Yields:
             UserRestriction: The next matching Toloker restriction.
@@ -3098,7 +3157,7 @@ class TolokaClient:
             >>> results_list = list(toloka_client.get_user_restrictions(scope='ALL_PROJECTS'))
             ...
         """
-        generator = self._find_all(self.find_user_restrictions, request)
+        generator = self._find_all(self.find_user_restrictions, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -3218,7 +3277,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_user_skills(self, request: search_requests.UserSkillSearchRequest) -> Generator[UserSkill, None, None]:
+    def get_user_skills(
+        self,
+        request: search_requests.UserSkillSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[UserSkill, None, None]:
         """Finds all Toloker's skills that match certain criteria.
 
         `get_user_skills` returns a generator. You can iterate over all found Toloker's skills using the generator. Several requests to the Toloka server are possible while iterating.
@@ -3227,6 +3290,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned skills limit for each request. The maximum allowed batch_size is 1000.
 
         Yields:
             UserSkill: The next matching Toloker's skill.
@@ -3235,7 +3299,7 @@ class TolokaClient:
             >>> results_list = list(toloka_client.get_user_skills())
             ...
         """
-        generator = self._find_all(self.find_user_skills, request)
+        generator = self._find_all(self.find_user_skills, request, batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -3364,7 +3428,8 @@ class TolokaClient:
     @add_headers('client')
     def get_webhook_subscriptions(
         self,
-        request: search_requests.WebhookSubscriptionSearchRequest
+        request: search_requests.WebhookSubscriptionSearchRequest,
+        batch_size: Optional[int] = None
     ) -> Generator[WebhookSubscription, None, None]:
         """Finds all webhook subscriptions that match certain criteria.
 
@@ -3374,11 +3439,12 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned webhook subscriptions limit for each request. The maximum allowed batch_size is 300.
 
         Yields:
             WebhookSubscription: The next matching webhook subscription.
         """
-        generator = self._find_all(self.find_webhook_subscriptions, request, sort_field='created')
+        generator = self._find_all(self.find_webhook_subscriptions, request, sort_field='created', batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -3475,7 +3541,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_app_projects(self, request: search_requests.AppProjectSearchRequest) -> Generator[AppProject, None, None]:
+    def get_app_projects(
+        self,
+        request: search_requests.AppProjectSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[AppProject, None, None]:
         """Finds all App projects that match certain criteria.
 
         `get_app_projects` returns a generator. You can iterate over all found projects using the generator. Several requests to the Toloka server are possible while iterating.
@@ -3484,6 +3554,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned projects limit for each request. The maximum batch_size is 5000.
 
         Yields:
             AppProject: The next matching App project.
@@ -3492,7 +3563,7 @@ class TolokaClient:
         if self.url != self.Environment.PRODUCTION.value:
             raise RuntimeError('this method supports only production environment')
 
-        generator = self._find_all(self.find_app_projects, request, items_field='content')
+        generator = self._find_all(self.find_app_projects, request, items_field='content', batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -3598,7 +3669,11 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_apps(self, request: search_requests.AppSearchRequest) -> Generator[App, None, None]:
+    def get_apps(
+        self,
+        request: search_requests.AppSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[App, None, None]:
         """Finds all App solutions that match certain criteria.
 
         `get_apps` returns a generator. You can iterate over all found solutions using the generator. Several requests to the Toloka server are possible while iterating.
@@ -3607,6 +3682,7 @@ class TolokaClient:
 
         Args:
             request: Search criteria.
+            batch_size: Returned solutions limit for each request. The maximum allowed batch_size is 1000.
 
         Yields:
             App: The next matching solution.
@@ -3615,7 +3691,7 @@ class TolokaClient:
         if self.url != self.Environment.PRODUCTION.value:
             raise RuntimeError('this method supports only production environment')
 
-        generator = self._find_all(self.find_apps, request, items_field='content')
+        generator = self._find_all(self.find_apps, request, items_field='content', batch_size=batch_size)
         yield from generator
 
     @add_headers('client')
@@ -3670,7 +3746,8 @@ class TolokaClient:
     @add_headers('client')
     def get_app_items(
         self,
-        app_project_id: str, request: search_requests.AppItemSearchRequest
+        app_project_id: str, request: search_requests.AppItemSearchRequest,
+        batch_size: Optional[int] = None
     ) -> Generator[AppItem, None, None]:
         """Finds all App task items that match certain criteria in an App project.
 
@@ -3681,6 +3758,7 @@ class TolokaClient:
         Args:
             app_project_id: The ID of the App project.
             request: Search criteria.
+            batch_size: Returned items limit for each request. The maximum allowed batch_size is 1000.
 
         Yields:
             AppItem: The next matching item.
@@ -3690,7 +3768,7 @@ class TolokaClient:
             raise RuntimeError('this method supports only production environment')
 
         find_function = functools.partial(self.find_app_items, app_project_id)
-        generator = self._find_all(find_function, request, items_field='content')
+        generator = self._find_all(find_function, request, items_field='content', batch_size=batch_size)
         yield from generator
 
     @expand('app_item')
@@ -3777,9 +3855,12 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def get_app_batches(self,
-                        app_project_id: str,
-                        request: search_requests.AppBatchSearchRequest) -> Generator[AppBatch, None, None]:
+    def get_app_batches(
+        self,
+        app_project_id: str,
+        request: search_requests.AppBatchSearchRequest,
+        batch_size: Optional[int] = None
+    ) -> Generator[AppBatch, None, None]:
         """Finds all batches that match certain criteria in an App project.
 
         `get_app_batches` returns a generator. You can iterate over all found batches using the generator. Several requests to the Toloka server are possible while iterating.
@@ -3789,6 +3870,7 @@ class TolokaClient:
         Args:
             app_project_id: The ID of the App project.
             request: Search criteria.
+            batch_size: Returned app batches limit for each request. The maximum allowed batch_size is 1000.
 
         Yields:
             AppBatch: The next matching batch.
@@ -3798,7 +3880,7 @@ class TolokaClient:
             raise RuntimeError('this method supports only production environment')
 
         find_function = functools.partial(self.find_app_batches, app_project_id)
-        generator = self._find_all(find_function, request, items_field='content')
+        generator = self._find_all(find_function, request, items_field='content', batch_size=batch_size)
         yield from generator
 
     @expand('request')


### PR DESCRIPTION
Add `batch_size` to each operation that involves returning a generator object to retrieve items in batches.

## Description
add `batch_size` parameter to `get_aggregated_solutions`. `get_assignments`. `get_attachments`. `get_message_threads`, `get_projects`, `get_pools`, `get_trainings`, `get_skills`, `get_tasks`, `get_task_suites`, `get_operations`, `get_user_bonuses`, `get_user_restrictions`, `get_user_skills`, `get_webhook_subscriptions`, `get_app_projects`, `get_apps`, `get_app_items`, `get_app_batches`.


### Connected issues (if any)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
