### PR TITLE
Replace Converter with BaseConverter for cattrs >= 22.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         'attrs >= 20.3.0',
         # cattr 22.2.0 breaks tests/primitives/test_operator.py
-        'cattrs >= 1.1.1, < 22.2.0',
+        'cattrs >= 1.1.1',
         'cached-property; python_version < "3.8.0"',
         'filelock >= 3.2.0',
         'requests',

--- a/src/client/_converter.py
+++ b/src/client/_converter.py
@@ -4,13 +4,17 @@ from decimal import Decimal
 import typing
 import re
 import uuid
+import pkg_resources
 from typing import List, Union
 
 import cattr
 from ..util._extendable_enum import ExtendableStrEnum
 
-
-converter = cattr.Converter()
+_CATTRS_VERSION = tuple(map(int, pkg_resources.get_distribution('cattrs').version.split('.')))
+if _CATTRS_VERSION < (22, 2, 0):
+    converter = cattr.Converter()
+else:
+    converter = cattr.converters.BaseConverter()
 
 converter.register_structure_hook_func(
     lambda type_: hasattr(type_, 'structure'),

--- a/tests/primitives/test_operator.py
+++ b/tests/primitives/test_operator.py
@@ -1,10 +1,12 @@
 import attr
 from toloka.client import structure, unstructure
 from toloka.client.primitives.operators import (
-    InclusionOperator, InclusionConditionMixin,
-    IdentityOperator, IdentityConditionMixin,
-    CompareOperator, ComparableConditionMixin,
-    # ComparableConditionMixin
+    InclusionOperator,
+    InclusionConditionMixin,
+    IdentityOperator,
+    IdentityConditionMixin,
+    CompareOperator,
+    ComparableConditionMixin,
 )
 
 


### PR DESCRIPTION
Use BaseConverter instead of Converter if version of cattrs >= 22.2.

## Description
Upper bound for cattrs was introduced in #114 because of `test_operator` break. The reason was that `Converter` became `BaseConverter` while `GenConverter` became `Converter` in [cattrs 22.2.0](https://catt.rs/en/stable/history.html#id1)

### Connected issues (if any)
#161


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
