### PR TITLE
Add field.quiz to undocumented components list

### DIFF
--- a/functional_tests/template_builder/test_completeness.py
+++ b/functional_tests/template_builder/test_completeness.py
@@ -34,6 +34,7 @@ UNDOCUMENTED_COMPONENTS = {
     'field.map',
     'field.tumbler',
     'field.map',  # TODO: possibly should be supported
+    'field.quiz',
 }
 
 


### PR DESCRIPTION
Add field.quiz to undocumented components list to prevent functional tests failure
