### PR TITLE
Allow structuring view specs with empty lock

### DIFF
--- a/src/client/project/view_spec.py
+++ b/src/client/project/view_spec.py
@@ -181,11 +181,12 @@ class TemplateBuilderViewSpec(ViewSpec, spec_value=ViewSpec.TEMPLATE_BUILDER):
         lock = data_copy.pop('lock')
 
         data_copy['config'] = json.loads(data['config'])
-        data_copy['core_version'] = lock['core']
+        if lock:
+            data_copy['core_version'] = lock['core']
 
-        for dct in traverse_dicts_recursively(data_copy['config']):
-            if dct.get('type') in lock:
-                dct['version'] = lock[dct['type']]
+            for dct in traverse_dicts_recursively(data_copy['config']):
+                if dct.get('type') in lock:
+                    dct['version'] = lock[dct['type']]
 
         return super().structure(data_copy)
 

--- a/tests/template_builder/test_template_builder.py
+++ b/tests/template_builder/test_template_builder.py
@@ -1,21 +1,22 @@
-import pytest
+import copy
 import json
 
+import pytest
 from toloka.client.project.field_spec import JsonSpec
-from toloka.client.project.view_spec import ViewSpec
 from toloka.client.project.template_builder import TemplateBuilder, get_input_and_output
 from toloka.client.project.template_builder.actions import SetActionV1
 from toloka.client.project.template_builder.base import RefComponent
 from toloka.client.project.template_builder.conditions import RequiredConditionV1
-from toloka.client.project.template_builder.data import OutputData, InputData
-from toloka.client.project.template_builder.fields import RadioGroupFieldV1, TextareaFieldV1, GroupFieldOption
+from toloka.client.project.template_builder.data import InputData, OutputData
+from toloka.client.project.template_builder.fields import GroupFieldOption, RadioGroupFieldV1, TextareaFieldV1
 from toloka.client.project.template_builder.layouts import SideBySideLayoutV1
 from toloka.client.project.template_builder.plugins import HotkeysPluginV1
-from toloka.client.project.template_builder.view import ListViewV1, ImageViewV1, TextViewV1
+from toloka.client.project.template_builder.view import ImageViewV1, ListViewV1, TextViewV1
+from toloka.client.project.view_spec import ViewSpec
 
 
 @pytest.fixture
-def view_spec_map():
+def view_spec_map_with_empty_lock():
     return {
         'settings': {
             'resolution': 1024,
@@ -124,18 +125,30 @@ def view_spec_map():
                 }
             }
         }),
-        "lock": {
-            'core': '1.0.0',
-            'condition.required': '1.0.0',
-            'field.textarea': '1.0.0',
-            'field.radio-group': '1.0.0',
-            'view.list': '1.0.0',
-            'view.image': '1.2.3',
-            'layout.side-by-side': '1.0.0',
-            'plugin.hotkeys': '1.0.0',
-            'action.set': '1.0.0',
-        }
+        'lock': None
     }
+
+
+def test_view_spec_map_with_empty_lock_is_structured_with_default_version(view_spec_map_with_empty_lock):
+    view_spec = ViewSpec.structure(view_spec_map_with_empty_lock)
+    assert view_spec.config.view.version == '1.0.0'
+
+
+@pytest.fixture
+def view_spec_map(view_spec_map_with_empty_lock):
+    view_spec_map = copy.deepcopy(view_spec_map_with_empty_lock)
+    view_spec_map['lock'] = {
+        'core': '1.0.0',
+        'condition.required': '1.0.0',
+        'field.textarea': '1.0.0',
+        'field.radio-group': '1.0.0',
+        'view.list': '1.0.0',
+        'view.image': '1.2.3',
+        'layout.side-by-side': '1.0.0',
+        'plugin.hotkeys': '1.0.0',
+        'action.set': '1.0.0',
+    }
+    return view_spec_map
 
 
 def test_result(view_spec_map):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -13,7 +13,7 @@ import pytest
 import toloka.client as client
 from httpx import QueryParams
 from toloka.client.exceptions import InternalApiError, ValidationApiError, IncorrectActionsApiError
-from .template_builder.test_template_builder import view_spec_map as tb_view_spec_map  # noqa: F401
+from .template_builder.test_template_builder import view_spec_map, view_spec_map_with_empty_lock  # noqa: F401
 
 from .testutils.util_functions import check_headers
 
@@ -80,8 +80,8 @@ def project_map():
 
 
 @pytest.fixture
-def tb_project_map(project_map, tb_view_spec_map):  # noqa F811
-    project_map['task_spec']['view_spec'] = tb_view_spec_map
+def tb_project_map(project_map, view_spec_map):  # noqa F811
+    project_map['task_spec']['view_spec'] = view_spec_map
     return project_map
 
 


### PR DESCRIPTION
In some legacy projects TemplateBuilderViewSpec json may contain lock field with `None` value. This PR changes serialization behavior so these projects can be structured using default version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
