### PR TITLE
Specify minimal tenacity version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'filelock >= 3.2.0',
         'requests',
         'httpx',
-        'tenacity',
+        'tenacity >= 7.0.0',  # https://github.com/jd/tenacity/issues/139
         'typing-extensions',
         'urllib3 >= 1.26.0',
         'simplejson',


### PR DESCRIPTION
Tenacity prior to version 7.0.0 has the following bug: https://github.com/jd/tenacity/issues/139. This breaks retrying mechanism for toloka-kit.