### PR TITLE
Use socket API for socket timeout server in retry tests

### DIFF
--- a/tests/slow_tests/test_retries.py
+++ b/tests/slow_tests/test_retries.py
@@ -126,7 +126,7 @@ def test_retries_off(connection_error_server_url, retries_before_response):
         'fake-token',
         url=connection_error_server_url,
         retries=0,
-        timeout=0.1
+        timeout=0.5
     )
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -142,7 +142,7 @@ async def test_retries_off_async(connection_error_server_url, retries_before_res
         'fake-token',
         url=connection_error_server_url,
         retries=0,
-        timeout=0.1
+        timeout=0.5
     )
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -157,7 +157,7 @@ def test_retries_from_int(connection_error_server_url, retries_before_response):
         'fake-token',
         url=connection_error_server_url,
         retries=retries_before_response - 1,
-        timeout=0.1
+        timeout=0.5
     )
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -173,7 +173,7 @@ async def test_retries_from_int_async(connection_error_server_url, retries_befor
         'fake-token',
         url=connection_error_server_url,
         retries=retries_before_response - 1,
-        timeout=0.1
+        timeout=0.5
     )
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -189,7 +189,7 @@ def test_retries_from_class(connection_error_server_url, retries_before_response
         url=connection_error_server_url,
         retries=Retry(retries_before_response - 1, status_forcelist={500}, backoff_factor=0),
         retry_quotas=None,
-        timeout=0.1
+        timeout=0.5
     )
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -206,7 +206,7 @@ async def test_retries_from_class_async(connection_error_server_url, retries_bef
         url=connection_error_server_url,
         retries=Retry(retries_before_response - 1, status_forcelist={500}, backoff_factor=0),
         retry_quotas=None,
-        timeout=0.1
+        timeout=0.5
     )
 
     with pytest.raises(httpx.HTTPStatusError):


### PR DESCRIPTION
Current "socket timeout" tests do not actually timeout sockets in a predictable way as accepting socket connections is handled by aiohttp (so the only option is to sleep and hope that the socket will not be closed by aiohttp). This PR replaces aiohttp server with a timeout server implementation over socket API


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
