### PR TITLE
Support event loop change in AsyncTolokaClient

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,13 @@ jobs:
     - name: Run tox with Python ${{ matrix.python-version }}
       run: |
         python -m tox
+    - name: Upload to codecov
+      if: ${{ matrix.python-version == '3.8' }}
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage_py38.xml
+        fail_ci_if_error: true
   build-docs:
     runs-on: ubuntu-latest
     steps:

--- a/src/async_client/client.py
+++ b/src/async_client/client.py
@@ -72,13 +72,14 @@ class AsyncTolokaClient:
         return self._sync_client
 
     @functools.lru_cache(maxsize=128)
-    def _session_for_thread(self, thread_id: int) -> httpx.AsyncClient:
+    def _session_for_thread_for_event_loop(self, thread_id: int, event_loop_id: int) -> httpx.AsyncClient:
         client = httpx.AsyncClient(headers=self._headers, base_url=self.url, verify=self.verify)
         return client
 
     @property
     def _session(self):
-        return self._session_for_thread(threading.current_thread().ident)
+        event_loop_id = id(asyncio.get_event_loop())
+        return self._session_for_thread_for_event_loop(threading.current_thread().ident, event_loop_id)
 
     async def _do_request_with_retries(self, method, path, **kwargs):
         @self.retrying.wraps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,13 +61,18 @@ class SyncOverAsyncTolokaClient:
 
 
 @pytest.fixture
-def sync_toloka_client():
-    return TolokaClient('fake-token', 'SANDBOX', timeout=0.1, retries=1)
+def environment():
+    return 'SANDBOX'
 
 
 @pytest.fixture
-def async_toloka_client():
-    return AsyncTolokaClient('fake-token', 'SANDBOX', timeout=0.1, retries=1)
+def sync_toloka_client(environment):
+    return TolokaClient('fake-token', environment, timeout=0.1, retries=1)
+
+
+@pytest.fixture
+def async_toloka_client(environment):
+    return AsyncTolokaClient('fake-token', environment, timeout=0.1, retries=1)
 
 
 @pytest.fixture(params=[True, False])
@@ -103,8 +108,8 @@ def toloka_client_prod(request) -> TolokaClient:
 
 
 @pytest.fixture
-def toloka_api_url(toloka_client) -> str:
-    return f'{toloka_client.url}/api'
+def toloka_api_url(environment) -> str:
+    return f'{TolokaClient.Environment[environment.upper()].value}/api'
 
 
 @pytest.fixture

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -174,7 +174,7 @@ def test_create_pool(respx_mock, toloka_client, toloka_url, pool_map, pool_map_w
     with caplog.at_level(logging.INFO):
         caplog.clear()
         result = toloka_client.create_pool(pool)
-        assert caplog.record_tuples == [(
+        assert [log for log in caplog.record_tuples if log[0] == 'toloka.client'] == [(
             'toloka.client', logging.INFO,
             'A new pool with ID "21" has been created. Link to open in web interface: https://sandbox.toloka.yandex.com/requester/project/10/pool/21'
         )]
@@ -973,7 +973,7 @@ def test_clone_pool(respx_mock, toloka_client, toloka_url,
     with caplog.at_level(logging.INFO):
         caplog.clear()
         result = toloka_client.clone_pool('21')
-        assert caplog.record_tuples == [(
+        assert [log for log in caplog.record_tuples if log[0] == 'toloka.client'] == [(
             'toloka.client',
             logging.INFO,
             'A new pool with ID "22" has been cloned. Link to open in web interface: https://sandbox.toloka.yandex.com/requester/project/10/pool/22'

--- a/tests/slow_tests/test_async.py
+++ b/tests/slow_tests/test_async.py
@@ -1,0 +1,43 @@
+import asyncio
+from threading import Thread
+
+from toloka.async_client import AsyncTolokaClient
+from urllib3 import Retry
+
+
+def test_async_client_survives_event_loop_change(connection_error_server_url, retries_before_response, fake_requester):
+    toloka_client = AsyncTolokaClient(
+        'fake-token',
+        url=connection_error_server_url,
+        retries=Retry(retries_before_response, status_forcelist={500}, backoff_factor=0),
+        retry_quotas=None,
+        timeout=0.5,
+    )
+
+    loop = asyncio.get_event_loop()
+    assert loop.run_until_complete(toloka_client.get_requester()) == fake_requester
+    loop.close()
+    loop = asyncio.new_event_loop()
+    assert loop.run_until_complete(toloka_client.get_requester()) == fake_requester
+
+
+def get_requester(result: list, client: AsyncTolokaClient):
+    result.append(asyncio.run(client.get_requester()))
+
+
+def test_async_client_can_be_multithreaded(connection_error_server_url, retries_before_response, fake_requester):
+    toloka_client = AsyncTolokaClient(
+        'fake-token',
+        url=connection_error_server_url,
+        retries=Retry(retries_before_response, status_forcelist={500}, backoff_factor=0),
+        retry_quotas=None,
+        timeout=0.5,
+    )
+    result = []
+    t1 = Thread(target=get_requester, args=(result, toloka_client))
+    t2 = Thread(target=get_requester, args=(result, toloka_client))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    assert result == [fake_requester, fake_requester]

--- a/tests/slow_tests/test_async.py
+++ b/tests/slow_tests/test_async.py
@@ -9,7 +9,7 @@ def test_async_client_survives_event_loop_change(connection_error_server_url, re
     toloka_client = AsyncTolokaClient(
         'fake-token',
         url=connection_error_server_url,
-        retries=Retry(retries_before_response, status_forcelist={500}, backoff_factor=0),
+        retryer_factory=lambda: Retry(retries_before_response, status_forcelist={500}, backoff_factor=0),
         retry_quotas=None,
         timeout=0.5,
     )
@@ -29,7 +29,7 @@ def test_async_client_can_be_multithreaded(connection_error_server_url, retries_
     toloka_client = AsyncTolokaClient(
         'fake-token',
         url=connection_error_server_url,
-        retries=Retry(retries_before_response, status_forcelist={500}, backoff_factor=0),
+        retryer_factory=lambda: Retry(retries_before_response, status_forcelist={500}, backoff_factor=0),
         retry_quotas=None,
         timeout=0.5,
     )

--- a/tests/streaming/test_shutdown.py
+++ b/tests/streaming/test_shutdown.py
@@ -25,7 +25,7 @@ def storage_directory(tmp_path):
     return dirname
 
 
-OBSERVER_DURATION = 0.4
+OBSERVER_DURATION = 2
 
 
 @attr.s

--- a/tests/streaming/test_shutdown.py
+++ b/tests/streaming/test_shutdown.py
@@ -1,21 +1,16 @@
 import asyncio
-import attr
 import datetime
 import os
-import pytest
 import signal
 import time
-from concurrent import futures
+from multiprocessing import Process
 from typing import Optional
 
+import attr
+import pytest
 from toloka.streaming import Pipeline
 from toloka.streaming.storage import JSONLocalStorage
 from toloka.util.async_utils import ComplexException
-
-
-@pytest.fixture
-def pid_file_path(tmp_path):
-    return tmp_path / 'to-kill-sigint.pid'
 
 
 @pytest.fixture
@@ -25,7 +20,7 @@ def storage_directory(tmp_path):
     return dirname
 
 
-OBSERVER_DURATION = 2
+OBSERVER_DURATION = 1
 
 
 @attr.s
@@ -67,30 +62,27 @@ def _create_pipeline(dirname: str, observer_name: str):
     return pipeline, observer, fail_observer
 
 
-def _run_pipeline(pid_file_path: str, dirname: str):
+def _run_pipeline(dirname: str):
     pipeline, _, _ = _create_pipeline(dirname, 'observer-before-ctrl-c')
-    pid = os.getpid()
-    with open(pid_file_path, 'w') as file:
-        file.write(str(pid))
     loop = asyncio.new_event_loop()
     loop.run_until_complete(pipeline.run())
 
 
-def _throw_sigint(pid_file_path: str, interrupt_after: float):
+def _throw_sigint(pid: int, interrupt_after: float):
     time.sleep(interrupt_after)
-    with open(pid_file_path) as file:
-        pid = int(file.read())
     os.kill(pid, signal.SIGINT)
 
 
-def test_gracefully_shutdown(pid_file_path, storage_directory):
-    with futures.ProcessPoolExecutor() as executor:
-        done, _ = futures.wait([executor.submit(_run_pipeline, pid_file_path, storage_directory),
-                                executor.submit(_throw_sigint, pid_file_path, OBSERVER_DURATION / 2)])
-        for task in done:
-            error = task.exception()
-            if error and not isinstance(error, futures.BrokenExecutor):
-                raise error
+def test_gracefully_shutdown(storage_directory):
+    pipeline_process = Process(target=_run_pipeline, args=(storage_directory,))
+    pipeline_process.start()
+    killer_process = Process(target=_throw_sigint, args=(pipeline_process.pid, OBSERVER_DURATION / 2))
+    killer_process.start()
+    pipeline_process.join()
+    killer_process.join()
+
+    assert pipeline_process.exitcode == 1
+    assert killer_process.exitcode == 0
 
     pipeline, observer, fail_observer = _create_pipeline(storage_directory, 'observer-after-ctrl-c')
     with pytest.raises(ComplexException):
@@ -104,28 +96,26 @@ LONG_WAIT_SECONDS = 10
 SHORT_OBSERVER_DURATION = 0.1
 
 
-def _run_long_sleeping_pipeline(pid_file_path: str):
+def _run_long_sleeping_pipeline():
     Pipeline.MIN_SLEEP_SECONDS = LONG_WAIT_SECONDS
     pipeline = Pipeline(period=datetime.timedelta(seconds=LONG_WAIT_SECONDS))
     pipeline.register(ObserverToInterrupt('short-observer', duration=SHORT_OBSERVER_DURATION))
-
-    pid = os.getpid()
-    with open(pid_file_path, 'w') as file:
-        file.write(str(pid))
     loop = asyncio.new_event_loop()
     loop.run_until_complete(pipeline.run())
 
 
-def test_interrupt_sleeping(pid_file_path):
+def test_interrupt_sleeping():
     start_time = time.time()
 
-    with futures.ProcessPoolExecutor() as executor:
-        done, _ = futures.wait([executor.submit(_run_long_sleeping_pipeline, pid_file_path),
-                                executor.submit(_throw_sigint, pid_file_path, SHORT_OBSERVER_DURATION * 1.5)])
-        for task in done:
-            error = task.exception()
-            if error and not isinstance(error, KeyboardInterrupt):
-                raise error
+    pipeline_process = Process(target=_run_long_sleeping_pipeline)
+    pipeline_process.start()
+    killer_process = Process(target=_throw_sigint, args=(pipeline_process.pid, OBSERVER_DURATION / 2))
+    killer_process.start()
+    pipeline_process.join()
+    killer_process.join()
+
+    assert pipeline_process.exitcode == 1
+    assert killer_process.exitcode == 0
 
     elapsed = time.time() - start_time
     assert elapsed < LONG_WAIT_SECONDS, elapsed

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,19 +1,17 @@
 import copy
-from decimal import Decimal
-
 import pickle
+import ssl
+from decimal import Decimal
 
 import httpx
 import pytest
 import simplejson
-import ssl
-from pytest_lazyfixture import lazy_fixture
-
-from toloka.client import TolokaClient
 import toloka.client as client
+from pytest_lazyfixture import lazy_fixture
+from toloka.client import TolokaClient
 
-from .testutils.util_functions import check_headers
 from .conftest import SyncOverAsyncTolokaClient
+from .testutils.util_functions import check_headers
 
 
 @pytest.fixture

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -310,7 +310,7 @@ def test_create_project(respx_mock, toloka_client, toloka_url, simple_project_ma
     with caplog.at_level(logging.INFO):
         caplog.clear()
         result = toloka_client.create_project(project)
-        assert caplog.record_tuples == [(
+        assert [log for log in caplog.record_tuples if log[0] == 'toloka.client'] == [(
             'toloka.client', logging.INFO,
             'A new project with ID "10" has been created. Link to open in web interface: https://sandbox.toloka.yandex.com/requester/project/10'
         )]

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -137,7 +137,7 @@ def test_create_skill(skill_sample, skill_header, respx_mock, toloka_client, tol
     with caplog.at_level(logging.INFO):
         caplog.clear()
         result = toloka_client.create_skill(client.Skill(**skill_header))
-        assert caplog.record_tuples == [(
+        assert [log for log in caplog.record_tuples if log[0] == 'toloka.client'] == [(
             'toloka.client',
             logging.INFO,
             'A new skill with ID "21" has been created. Link to open in web interface: https://sandbox.toloka.yandex.com/requester/quality/skill/21'

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -179,7 +179,7 @@ def test_create_training(respx_mock, toloka_client, toloka_url, training_map, tr
     with caplog.at_level(logging.INFO):
         caplog.clear()
         result = toloka_client.create_training(training)
-        assert caplog.record_tuples == [(
+        assert [log for log in caplog.record_tuples if log[0] == 'toloka.client'] == [(
             'toloka.client',
             logging.INFO,
             'A new training with ID "21" has been created. Link to open in web interface: https://sandbox.toloka.yandex.com/requester/project/10/training/21'
@@ -601,7 +601,7 @@ def test_clone_training(respx_mock, toloka_client, toloka_url,
     with caplog.at_level(logging.INFO):
         caplog.clear()
         result = toloka_client.clone_training('21')
-        assert caplog.record_tuples == [(
+        assert [log for log in caplog.record_tuples if log[0] == 'toloka.client'] == [(
             'toloka.client',
             logging.INFO,
             'A new training with ID "22" has been cloned. Link to open in web interface: https://sandbox.toloka.yandex.com/requester/project/10/training/22'

--- a/tox.ini
+++ b/tox.ini
@@ -44,21 +44,16 @@ extras =
     zookeeper: zookeeper
     jupyter-metrics: jupyter-metrics
 
-
 # For Python 3.8 we additionally collect test coverage
 # information and upload it to codecov
 [testenv:py38-attrs21-all]
 deps =
     {[testenv]deps}
     coverage
-    codecov
-passenv =
-    CI
-    CODECOV_*
 commands =
-    coverage run --source {envsitepackagesdir}/toloka/client -m pytest tests
-    codecov
     mypy --no-strict-optional src/client
+    coverage run --source {envsitepackagesdir}/toloka/client -m pytest tests
+    coverage xml -o coverage_py38.xml
 
 # Test that stubs can be generated
 [testenv:py310-stubgeneration-all]

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,8 @@ deps =
     {[testenv]deps}
     coverage
 commands =
-    mypy --no-strict-optional src/client
-    coverage run --source {envsitepackagesdir}/toloka/client -m pytest tests
+    mypy --no-strict-optional src
+    coverage run --source {envsitepackagesdir}/toloka -m pytest tests
     coverage xml -o coverage_py38.xml
 
 # Test that stubs can be generated


### PR DESCRIPTION
Currently `httpx.AsyncClient` is cached unconditionally inside `AsyncTolokaClient`. This leads to an error if the client instance is reused in multiple asyncio event loops (e.g. if `asyncio.run` is called multiple times for a single `AsyncTolokaClient` instance).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
