### PR TITLE
Fail on failed operation received during a retry attempt 

### DIFF
--- a/src/async_client/client.py
+++ b/src/async_client/client.py
@@ -7,10 +7,11 @@ import functools
 import logging
 import threading
 from decimal import Decimal
-from typing import Optional, Callable, List
+from typing import Dict, Optional, Callable, List
 
 import attr
 import httpx
+from toloka.client.batch_create_results import FieldValidationError
 
 from ..client import TolokaClient, structure, unstructure
 from ..client.exceptions import (
@@ -162,7 +163,7 @@ class AsyncTolokaClient:
                 numerated_ids = pools.setdefault(log_item.input['pool_id'], {})
                 numerated_ids[log_item.output[output_id_field]] = index
             else:
-                validation_errors[index] = log_item.output
+                validation_errors[index] = structure(log_item.output, Dict[str, FieldValidationError])
 
         # Like in sync methods Exception will raise
         # even if the skip_invalid_items=True but no objects are created

--- a/src/client/exceptions.py
+++ b/src/client/exceptions.py
@@ -74,7 +74,11 @@ class ApiError(Exception):
         code = f'Code of error: {self.code}'
         error_details = f'Error details: {self.message}'
         if self.payload:
-            additional_info = 'Additional information about the error:\n' + json.dumps(self.payload, indent=4)
+            try:
+                payload_str = json.dumps(self.payload, indent=4)
+            except TypeError:
+                payload_str = f'failed to parse payload as JSON! Falling back to raw representation:\n{self.payload}'
+            additional_info = 'Additional information about the error:\n' + payload_str
         else:
             additional_info = ''
         request_id = f'request id: {self.request_id}. It needs to be specified when contacting support.'

--- a/tests/task_suites/test_creation.py
+++ b/tests/task_suites/test_creation.py
@@ -216,7 +216,7 @@ def task_suites_result_map(task_suite_1, task_suite_2):
 
 
 def test_create_task_suite_sync_through_async(
-        respx_mock, toloka_client, toloka_url, no_uuid_random,
+        respx_mock, toloka_client, toloka_url,
         task_suites_map, operation_running_map_single_task_suite, operation_success_map_single_task_suite,
         create_log, task_suite_1,
 ):
@@ -226,6 +226,7 @@ def test_create_task_suite_sync_through_async(
     assert_sync_via_async_object_creation_is_successful(
         respx_mock=respx_mock,
         toloka_url=toloka_url,
+        toloka_client=toloka_client,
         create_method=toloka_client.create_task_suite,
         create_method_kwargs={
             'task_suite': task_suite,
@@ -246,11 +247,13 @@ def test_create_task_suite_sync_through_async(
             'open_pool': 'true',
             'async_mode': 'true',
         },
+        top_level_method_header='create_task_suite',
+        low_level_method_header='create_task_suite'
     )
 
 
 def test_create_task_suite_sync_through_async_retry(
-    respx_mock, toloka_client, toloka_url, no_uuid_random, task_suites_map, operation_success_map_single_task_suite,
+    respx_mock, toloka_client, toloka_url, task_suites_map, operation_success_map_single_task_suite,
     create_log, task_suite_1
 ):
     task_suite = task_suites_map[0]
@@ -273,11 +276,9 @@ def test_create_task_suite_sync_through_async_retry(
 
 
 def test_create_task_suite_sync_through_async_retry_failed_operation(
-    respx_mock, toloka_client, toloka_url, no_uuid_random, task_suites_map, operation_fail_map_single_task_suite,
-    create_log, task_suite_1
+    respx_mock, toloka_client, toloka_url, task_suites_map, operation_fail_map_single_task_suite,
 ):
     task_suite = task_suites_map[0]
-    create_log = create_log[:1]
 
     assert_retried_failed_operation_fails_with_failed_operation_exception(
         respx_mock=respx_mock,
@@ -286,22 +287,20 @@ def test_create_task_suite_sync_through_async_retry_failed_operation(
         create_method_kwargs={
             'task_suite': client.structure(task_suite, client.TaskSuite)
         },
-        returned_object=task_suite_1,
         failed_operation_map=operation_fail_map_single_task_suite,
-        operation_log=create_log,
         create_object_path='task-suites',
-        get_object_path=f'task-suites/{task_suite_1["id"]}',
     )
 
 
 def test_create_task_suites_sync_through_async(
-    respx_mock, toloka_client, toloka_url, no_uuid_random,
+    respx_mock, toloka_client, toloka_url,
     task_suites_map, operation_running_map, operation_success_map,
     create_log, get_task_suites_map, task_suites_result_map
 ):
     assert_sync_via_async_object_creation_is_successful(
         respx_mock=respx_mock,
         toloka_url=toloka_url,
+        toloka_client=toloka_client,
         create_method=toloka_client.create_task_suites,
         create_method_kwargs={
             'task_suites': [client.structure(t, client.task_suite.TaskSuite) for t in task_suites_map],
@@ -324,11 +323,13 @@ def test_create_task_suites_sync_through_async(
             'async_mode': 'true',
             'skip_invalid_items': 'true',
         },
+        top_level_method_header='create_task_suites',
+        low_level_method_header='create_task_suites',
     )
 
 
 def test_create_task_suites_sync_through_async_retry(
-    respx_mock, toloka_client, toloka_url, task_suites_map, operation_success_map, create_log, no_uuid_random,
+    respx_mock, toloka_client, toloka_url, task_suites_map, operation_success_map, create_log,
     get_task_suites_map, task_suites_result_map
 ):
     assert_retried_sync_via_async_object_creation_returns_already_existing_object(
@@ -348,9 +349,7 @@ def test_create_task_suites_sync_through_async_retry(
 
 
 def test_create_task_suites_sync_through_async_retry_failed_operation(
-    respx_mock, toloka_client, toloka_url, no_uuid_random,
-    task_suites_map, operation_running_map, operation_fail_map,
-    create_log, get_task_suites_map, task_suites_result_map
+    respx_mock, toloka_client, toloka_url, task_suites_map, operation_fail_map,
 ):
     assert_retried_failed_operation_fails_with_failed_operation_exception(
         respx_mock=respx_mock,
@@ -362,11 +361,8 @@ def test_create_task_suites_sync_through_async_retry_failed_operation(
             'allow_defaults': True,
             'open_pool': True,
         },
-        returned_object={'items': get_task_suites_map, 'has_more': False},
         failed_operation_map=operation_fail_map,
-        operation_log=create_log,
         create_object_path='task-suites',
-        get_object_path=f'task-suites',
     )
 
 
@@ -405,4 +401,19 @@ def test_create_task_suites_async_retry(respx_mock, toloka_client, toloka_url, t
         },
         create_object_path='task-suites',
         success_operation_map=operation_success_map
+    )
+
+
+def test_create_task_suites_async_retry_failed_operation(
+    respx_mock, toloka_client, toloka_url, task_suites_map, operation_fail_map
+):
+    assert_retried_failed_operation_fails_with_failed_operation_exception(
+        respx_mock=respx_mock,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_task_suites_async,
+        create_method_kwargs={
+            'task_suites': [client.structure(task_suite, client.TaskSuite) for task_suite in task_suites_map]
+        },
+        failed_operation_map=operation_fail_map,
+        create_object_path='task-suites',
     )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -50,3 +50,17 @@ def test_api_error_to_str():
         }
     }
     request id: asd123. It needs to be specified when contacting support.''')
+
+
+def test_api_error_with_bad_payload_falls_back_to_printing_raw_response():
+    bad_payload = object()
+    assert str(ApiError(status_code=500, request_id='asd123', code='INTERNAL_ERROR', payload=bad_payload)) == dedent(
+        f'''\
+        You have got a(n) ApiError with http status code: 500
+        Code of error: INTERNAL_ERROR
+        Error details: None
+        Additional information about the error:
+        failed to parse error payload as JSON, falling back to naive string representation
+        {str(bad_payload)}
+        request id: asd123. It needs to be specified when contacting support.'''
+    )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -60,7 +60,7 @@ def test_api_error_with_bad_payload_falls_back_to_printing_raw_response():
         Code of error: INTERNAL_ERROR
         Error details: None
         Additional information about the error:
-        failed to parse error payload as JSON, falling back to naive string representation
+        failed to parse payload as JSON! Falling back to raw representation:
         {str(bad_payload)}
         request id: asd123. It needs to be specified when contacting support.'''
     )

--- a/tests/testutils/util_functions.py
+++ b/tests/testutils/util_functions.py
@@ -1,4 +1,10 @@
+import re
+from typing import Callable, Optional
+
 import httpx
+from toloka import client as client
+from toloka.client.exceptions import IncorrectActionsApiError
+from toloka.client.primitives.base import BaseTolokaObject
 
 
 def check_headers(request, expected_headers):
@@ -6,3 +12,64 @@ def check_headers(request, expected_headers):
         assert set((key.lower(), value.lower()) for key, value in expected_headers.items()) <= request.headers.items()
     else:
         assert expected_headers.items() <= request._request.headers.items()
+
+
+def assert_retried_object_creation_returns_already_existing_object(
+    respx_mock,
+    toloka_url: str,
+    create_method: Callable,
+    create_method_kwargs: dict,
+    get_object_side_effect: Optional[Callable],
+    expected_response_object: BaseTolokaObject,
+    success_operation_map: dict,
+    operation_log: Optional[list],
+    create_object_path: str,
+    get_object_path: str,
+) -> None:
+    requests_count = 0
+    first_request_op_id = None
+
+    def create_object(request):
+        nonlocal requests_count
+        nonlocal first_request_op_id
+
+        requests_count += 1
+        if requests_count == 1:
+            first_request_op_id = request.url.params['operation_id']
+            expected_operation_id = create_method_kwargs.get('operation_id')
+            if expected_operation_id:
+                assert first_request_op_id == expected_operation_id
+            return httpx.Response(status_code=500)
+
+        assert request.url.params['operation_id'] == str(first_request_op_id)
+
+        unstructured_error = client.unstructure(
+            IncorrectActionsApiError(
+                code='OPERATION_ALREADY_EXISTS',
+            )
+        )
+        del unstructured_error['status_code']
+
+        return httpx.Response(
+            json=unstructured_error,
+            status_code=409
+        )
+
+    respx_mock.post(f'{toloka_url}/{create_object_path}').mock(side_effect=create_object)
+
+    respx_mock.get(
+        url__regex=rf'{toloka_url}/operations/.*(?<!log)$'
+    ).mock(httpx.Response(json=success_operation_map, status_code=201))
+
+    if operation_log is not None:
+        respx_mock.get(re.compile(rf'{toloka_url}/operations/.*/log')).mock(
+            httpx.Response(json=operation_log, status_code=201)
+        )
+
+    if get_object_side_effect is not None:
+        respx_mock.get(f'{toloka_url}/{get_object_path}').mock(side_effect=get_object_side_effect)
+
+    result = create_method(**create_method_kwargs)
+
+    assert expected_response_object == result
+    assert requests_count == 2

--- a/tests/testutils/util_functions.py
+++ b/tests/testutils/util_functions.py
@@ -1,9 +1,12 @@
 import re
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import httpx
+import pytest
+from httpx import QueryParams
 from toloka import client as client
-from toloka.client.exceptions import IncorrectActionsApiError
+from toloka.client.exceptions import FailedOperation, IncorrectActionsApiError
+from toloka.client.operations import Operation
 from toloka.client.primitives.base import BaseTolokaObject
 
 
@@ -14,18 +17,81 @@ def check_headers(request, expected_headers):
         assert expected_headers.items() <= request._request.headers.items()
 
 
-def assert_retried_object_creation_returns_already_existing_object(
+def assert_sync_via_async_object_creation_is_successful(
     respx_mock,
     toloka_url: str,
     create_method: Callable,
     create_method_kwargs: dict,
-    get_object_side_effect: Optional[Callable],
+    returned_object: Union[dict, Callable],
     expected_response_object: BaseTolokaObject,
-    success_operation_map: dict,
     operation_log: Optional[list],
     create_object_path: str,
     get_object_path: str,
-) -> None:
+    operation_running: Operation,
+    success_operation: Operation,
+    expected_query_params: dict,
+):
+    def create_object(request):
+        assert QueryParams(**expected_query_params) == request.url.params
+        return httpx.Response(json=operation_running.unstructure(), status_code=201)
+
+    respx_mock.post(f'{toloka_url}/{create_object_path}').mock(side_effect=create_object)
+    respx_mock.get(url__regex=rf'{toloka_url}/operations/.*(?<!log)$').mock(
+        httpx.Response(json=success_operation.unstructure(), status_code=201)
+    )
+    if operation_log is not None:
+        respx_mock.get(re.compile(rf'{toloka_url}/operations/.*/log')).mock(
+            httpx.Response(json=operation_log, status_code=201)
+        )
+    if isinstance(returned_object, dict):
+        respx_mock.get(f'{toloka_url}/{get_object_path}').mock(httpx.Response(json=returned_object, status_code=200))
+    else:
+        respx_mock.get(f'{toloka_url}/{get_object_path}').mock(side_effect=returned_object)
+
+    result = create_method(**create_method_kwargs)
+    assert result == expected_response_object
+
+
+def assert_async_object_creation_is_successful(
+    respx_mock,
+    toloka_client,
+    toloka_url: str,
+    create_method: Callable,
+    create_method_kwargs: dict,
+    create_object_path: str,
+    success_operation_map: dict,
+    expected_query_params: dict,
+    top_level_method_header: str,
+    low_level_method_header: str,
+):
+    def create_object(request):
+        expected_headers = {
+            'X-Caller-Context': 'client' if isinstance(toloka_client, client.TolokaClient) else 'async_client',
+            'X-Top-Level-Method': top_level_method_header,
+            'X-Low-Level-Method': low_level_method_header,
+        }
+        check_headers(request, expected_headers)
+        assert QueryParams(**{**expected_query_params, 'operation_id': request.url.params['operation_id']}) \
+               == request.url.params
+        return httpx.Response(json=success_operation_map, status_code=200)
+
+    respx_mock.post(f'{toloka_url}/{create_object_path}').mock(side_effect=create_object)
+    respx_mock.get(url__regex=rf'{toloka_url}/operations/.*(?<!log)$').mock(
+        httpx.Response(json=success_operation_map, status_code=201)
+    )
+
+    result = create_method(**create_method_kwargs)
+    assert result == Operation.structure(success_operation_map)
+
+
+def assert_retried_async_object_creation_returns_existing_operation(
+    respx_mock,
+    toloka_url: str,
+    create_method: Callable,
+    create_method_kwargs: dict,
+    create_object_path: str,
+    success_operation_map: dict,
+):
     requests_count = 0
     first_request_op_id = None
 
@@ -35,6 +101,113 @@ def assert_retried_object_creation_returns_already_existing_object(
 
         requests_count += 1
         if requests_count == 1:
+            first_request_op_id = request.url.params['operation_id']
+            return httpx.Response(status_code=500)
+
+        assert request.url.params['operation_id'] == first_request_op_id
+        unstructured_error = client.unstructure(
+            IncorrectActionsApiError(
+                code='OPERATION_ALREADY_EXISTS',
+            )
+        )
+        del unstructured_error['status_code']
+
+        return httpx.Response(
+            json=unstructured_error,
+            status_code=409
+        )
+
+    respx_mock.get(
+        re.compile(rf'{toloka_url}/operations/.*')
+    ).mock(httpx.Response(json=success_operation_map, status_code=200))
+    respx_mock.post(f'{toloka_url}/{create_object_path}').mock(side_effect=create_object)
+
+    result = create_method(**create_method_kwargs)
+    assert requests_count == 2
+    assert result == Operation.structure(success_operation_map)
+
+
+def assert_retried_sync_via_async_object_creation_returns_already_existing_object(
+    respx_mock,
+    toloka_url: str,
+    create_method: Callable,
+    create_method_kwargs: dict,
+    returned_object: Union[Callable, dict],
+    expected_response_object: BaseTolokaObject,
+    success_operation_map: dict,
+    operation_log: Optional[list],
+    create_object_path: str,
+    get_object_path: str,
+) -> None:
+    requests_counter = _mock_faulty_object_creation_environment(
+        create_object_path=create_object_path,
+        get_object_path=get_object_path,
+        returned_object=returned_object,
+        operation_log=operation_log,
+        respx_mock=respx_mock,
+        operation_map=success_operation_map,
+        toloka_url=toloka_url,
+        create_method_kwargs=create_method_kwargs,
+    )
+
+    result = create_method(**create_method_kwargs)
+
+    assert result == expected_response_object
+    assert requests_counter.value == 2
+
+
+def assert_retried_failed_operation_fails_with_failed_operation_exception(
+    respx_mock,
+    toloka_url: str,
+    create_method: Callable,
+    create_method_kwargs: dict,
+    returned_object: Union[Callable, dict],
+    failed_operation_map: dict,
+    operation_log: Optional[list],
+    create_object_path: str,
+    get_object_path: str,
+):
+    requests_counter = _mock_faulty_object_creation_environment(
+        create_object_path=create_object_path,
+        get_object_path=get_object_path,
+        returned_object=returned_object,
+        operation_log=operation_log,
+        respx_mock=respx_mock,
+        operation_map=failed_operation_map,
+        toloka_url=toloka_url,
+        create_method_kwargs=create_method_kwargs,
+    )
+
+    with pytest.raises(FailedOperation):
+        create_method(**create_method_kwargs)
+
+    assert requests_counter.value == 2
+
+
+class Counter:
+    def __init__(self):
+        self.value = 0
+
+
+def _mock_faulty_object_creation_environment(
+    create_object_path,
+    get_object_path,
+    returned_object: Union[Callable, dict],
+    operation_log,
+    respx_mock,
+    operation_map,
+    toloka_url,
+    create_method_kwargs,
+):
+    requests_count = Counter()
+    first_request_op_id = None
+
+    def create_object(request):
+        nonlocal requests_count
+        nonlocal first_request_op_id
+
+        requests_count.value += 1
+        if requests_count.value == 1:
             first_request_op_id = request.url.params['operation_id']
             expected_operation_id = create_method_kwargs.get('operation_id')
             if expected_operation_id:
@@ -56,20 +229,17 @@ def assert_retried_object_creation_returns_already_existing_object(
         )
 
     respx_mock.post(f'{toloka_url}/{create_object_path}').mock(side_effect=create_object)
-
     respx_mock.get(
         url__regex=rf'{toloka_url}/operations/.*(?<!log)$'
-    ).mock(httpx.Response(json=success_operation_map, status_code=201))
-
+    ).mock(httpx.Response(json=operation_map, status_code=201))
     if operation_log is not None:
         respx_mock.get(re.compile(rf'{toloka_url}/operations/.*/log')).mock(
             httpx.Response(json=operation_log, status_code=201)
         )
-
-    if get_object_side_effect is not None:
-        respx_mock.get(f'{toloka_url}/{get_object_path}').mock(side_effect=get_object_side_effect)
-
-    result = create_method(**create_method_kwargs)
-
-    assert expected_response_object == result
-    assert requests_count == 2
+    if isinstance(returned_object, dict):
+        respx_mock.get(f'{toloka_url}/{get_object_path}').mock(
+            httpx.Response(json=returned_object, status_code=201)
+        )
+    else:
+        respx_mock.get(f'{toloka_url}/{get_object_path}').mock(side_effect=returned_object)
+    return requests_count

--- a/tests/testutils/util_functions.py
+++ b/tests/testutils/util_functions.py
@@ -95,7 +95,7 @@ def assert_async_object_creation_is_successful(
     )
 
     result = create_method(**create_method_kwargs)
-    assert result == Operation.structure(success_operation_map)
+    assert result.unstructure() == success_operation_map
 
 
 def assert_retried_async_object_creation_returns_existing_operation(

--- a/tests/user_bonuses/test_creation.py
+++ b/tests/user_bonuses/test_creation.py
@@ -11,10 +11,13 @@ from httpx import QueryParams
 from toloka.client import UserBonus
 from toloka.client.batch_create_results import UserBonusBatchCreateResult
 from toloka.client.exceptions import FailedOperation, IncorrectActionsApiError
+from toloka.client.operations import Operation
 
 from ..testutils.util_functions import (
+    assert_async_object_creation_is_successful, assert_retried_async_object_creation_returns_existing_operation,
     assert_retried_failed_operation_fails_with_failed_operation_exception,
-    assert_retried_sync_via_async_object_creation_returns_already_existing_object, check_headers,
+    assert_retried_sync_via_async_object_creation_returns_already_existing_object,
+    assert_sync_via_async_object_creation_is_successful, check_headers,
 )
 
 
@@ -174,65 +177,40 @@ def test_create_user_bonus_sync_via_async(
     create_user_bonus_operation_running, create_user_bonus_operation_success, create_user_bonus_log,
     operation_id
 ):
-
-    def user_bonus(request):
-        expected_headers = {
-            'X-Caller-Context': 'client' if isinstance(toloka_client, client.TolokaClient) else 'async_client',
-            'X-Top-Level-Method': 'create_user_bonus',
-            'X-Low-Level-Method': 'create_user_bonus',
-        }
-        check_headers(request, expected_headers)
-
-        assert QueryParams(
-            operation_id=str(operation_id),
-            async_mode='true',
-        ) == request.url.params
-        incoming_user_bonus = simplejson.loads(request.content)
-        assert '__item_idx' in incoming_user_bonus
-        incoming_user_bonus.pop('__item_idx')
-        assert user_bonus_map == incoming_user_bonus
-        return httpx.Response(json=create_user_bonus_operation_running, status_code=201)
-
-    def user_bonus_op(request):
-        return httpx.Response(json=create_user_bonus_operation_success, status_code=201)
-
-    def user_bonus_log(request):
-        return httpx.Response(text=simplejson.dumps(create_user_bonus_log), status_code=201)
-
-    def return_user_bonus(request):
-        return httpx.Response(text=simplejson.dumps(user_bonus_map_with_readonly), status_code=200)
-
-    respx_mock.post(f'{toloka_url}/user-bonuses').mock(side_effect=user_bonus)
-    respx_mock.get(f'{toloka_url}/operations/{create_user_bonus_operation_running["id"]}').mock(
-        side_effect=user_bonus_op
-    )
-    respx_mock.get(f'{toloka_url}/operations/{create_user_bonus_operation_running["id"]}/log').mock(
-        side_effect=user_bonus_log
-    )
-    respx_mock.get(f'{toloka_url}/user-bonuses/user-bonus-1').mock(side_effect=return_user_bonus)
-
     user_bonus = client.structure(user_bonus_map, client.user_bonus.UserBonus)
 
-    result = toloka_client.create_user_bonus(
-        user_bonus,
-        operation_id=operation_id,
+    assert_sync_via_async_object_creation_is_successful(
+        respx_mock=respx_mock,
+        toloka_client=toloka_client,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_user_bonus,
+        create_method_kwargs={'user_bonus': user_bonus, 'operation_id': operation_id},
+        returned_object=simplejson.dumps(user_bonus_map_with_readonly),
+        expected_response_object=UserBonus.structure(user_bonus_map_with_readonly),
+        operation_log=simplejson.dumps(create_user_bonus_log),
+        create_object_path='user-bonuses',
+        get_object_path='user-bonuses/user-bonus-1',
+        operation_running=Operation.structure(create_user_bonus_operation_running),
+        success_operation=Operation.structure(create_user_bonus_operation_success),
+        expected_query_params={
+            'operation_id': str(operation_id),
+            'async_mode': 'true',
+        },
+        top_level_method_header='create_user_bonus',
+        low_level_method_header='create_user_bonus',
     )
-    assert user_bonus_map_with_readonly == client.unstructure(result)
 
 
 def test_create_user_bonus_sync_via_async_retry(
     respx_mock, toloka_client, toloka_url, user_bonus_map, user_bonus_map_with_readonly,
-    create_user_bonus_operation_success, create_user_bonus_log, operation_id,
+    create_user_bonus_operation_success, create_user_bonus_log,
 ):
-    def user_bonus(request):
-        return httpx.Response(text=simplejson.dumps(user_bonus_map_with_readonly), status_code=200)
-
     assert_retried_sync_via_async_object_creation_returns_already_existing_object(
         respx_mock=respx_mock,
         toloka_url=toloka_url,
         create_method=toloka_client.create_user_bonus,
         create_method_kwargs={'user_bonus': UserBonus.structure(user_bonus_map)},
-        returned_object=user_bonus,
+        returned_object=simplejson.dumps(user_bonus_map_with_readonly),
         expected_response_object=UserBonus.structure(user_bonus_map_with_readonly),
         success_operation_map=create_user_bonus_operation_success,
         operation_log=create_user_bonus_log,
@@ -243,48 +221,21 @@ def test_create_user_bonus_sync_via_async_retry(
 
 def test_create_user_bonus_sync_via_async_retry_failed_operation(
     respx_mock, toloka_client, toloka_url,
-    user_bonus_map, user_bonus_map_with_readonly, create_user_bonus_operation_fail, create_user_bonus_log,
+    user_bonus_map, create_user_bonus_operation_fail,
     operation_id
 ):
-    requests_count = 0
-
-    def user_bonuses(request):
-        nonlocal requests_count
-
-        requests_count += 1
-        if requests_count == 1:
-            return httpx.Response(status_code=500)
-
-        assert request.url.params['operation_id'] == str(operation_id)
-        unstructured_error = client.unstructure(
-            IncorrectActionsApiError(
-                code='OPERATION_ALREADY_EXISTS',
-            )
-        )
-        del unstructured_error['status_code']
-
-        return httpx.Response(
-            json=unstructured_error,
-            status_code=409
-        )
-
-    def user_bonus_op(request):
-        return httpx.Response(json=create_user_bonus_operation_fail, status_code=201)
-
-    def user_bonus_log(request):
-        return httpx.Response(text=simplejson.dumps(create_user_bonus_log), status_code=201)
-
-    respx_mock.post(f'{toloka_url}/user-bonuses').mock(side_effect=user_bonuses)
-
-    respx_mock.get(f'{toloka_url}/operations/{str(operation_id)}').mock(side_effect=user_bonus_op)
-    respx_mock.get(f'{toloka_url}/operations/{str(operation_id)}/log').mock(side_effect=user_bonus_log)
-
     user_bonus = client.structure(user_bonus_map, client.user_bonus.UserBonus)
-
-    with pytest.raises(FailedOperation):
-        toloka_client.create_user_bonus(user_bonus, operation_id=operation_id)
-
-    assert requests_count == 2
+    assert_retried_failed_operation_fails_with_failed_operation_exception(
+        respx_mock=respx_mock,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_user_bonus,
+        create_method_kwargs={
+            'user_bonus': user_bonus,
+            'operation_id': operation_id,
+        },
+        failed_operation_map=create_user_bonus_operation_fail,
+        create_object_path='user-bonuses',
+    )
 
 
 def test_create_user_bonuses_without_message(
@@ -413,58 +364,29 @@ def test_create_user_bonuses_sync_via_async(
     create_user_bonuses_operation_running, create_user_bonuses_operation_success, create_user_bonuses_log,
     user_bonuses_result_map
 ):
-    def check_user_bonuses(request):
-        expected_headers = {
-            'X-Caller-Context': 'client' if isinstance(toloka_client, client.TolokaClient) else 'async_client',
-            'X-Top-Level-Method': 'create_user_bonuses',
-            'X-Low-Level-Method': 'create_user_bonuses',
-        }
-        check_headers(request, expected_headers)
-
-        assert QueryParams(
-            operation_id=str(create_user_bonuses_operation_id),
-            async_mode='true',
-        ) == request.url.params
-
-        incoming_user_bonuses = []
-        for ub in simplejson.loads(request.content):
-            assert '__item_idx' in ub
-            ub.pop('__item_idx')
-            incoming_user_bonuses.append(ub)
-        assert user_bonus_map_async == incoming_user_bonuses
-        return httpx.Response(json=create_user_bonuses_operation_running, status_code=201)
-
-    def user_bonuses_op(request):
-        return httpx.Response(json=create_user_bonuses_operation_success, status_code=201)
-
-    def user_bonuses_log(request):
-        return httpx.Response(text=simplejson.dumps(create_user_bonuses_log), status_code=201)
-
-    def return_user_bonuses(request):
-        return httpx.Response(
-            text=simplejson.dumps({'items': user_bonus_map_async_with_read_only, 'has_more': False}),
-            status_code=200
-        )
-
-    respx_mock.post(f'{toloka_url}/user-bonuses').mock(side_effect=check_user_bonuses)
-    respx_mock.get(f'{toloka_url}/operations/{create_user_bonuses_operation_running["id"]}').mock(
-        side_effect=user_bonuses_op
+    assert_sync_via_async_object_creation_is_successful(
+        respx_mock=respx_mock,
+        toloka_client=toloka_client,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_user_bonuses,
+        create_method_kwargs={
+            'user_bonuses': client.structure(user_bonus_map_async, List[UserBonus]),
+            'operation_id': create_user_bonuses_operation_id
+        },
+        returned_object=simplejson.dumps({'items': user_bonus_map_async_with_read_only, 'has_more': False}),
+        expected_response_object=UserBonusBatchCreateResult.structure(user_bonuses_result_map),
+        operation_log=simplejson.dumps(create_user_bonuses_log),
+        create_object_path='user-bonuses',
+        get_object_path='user-bonuses',
+        operation_running=Operation.structure(create_user_bonuses_operation_running),
+        success_operation=Operation.structure(create_user_bonuses_operation_success),
+        expected_query_params={
+            'async_mode': 'true',
+            'operation_id': str(create_user_bonuses_operation_id),
+        },
+        top_level_method_header='create_user_bonuses',
+        low_level_method_header='create_user_bonuses',
     )
-    respx_mock.get(f'{toloka_url}/operations/{create_user_bonuses_operation_running["id"]}/log').mock(
-        side_effect=user_bonuses_log
-    )
-    respx_mock.get(f'{toloka_url}/user-bonuses').mock(side_effect=return_user_bonuses)
-
-    user_bonuses = [
-        client.structure(user_bonus_map, client.user_bonus.UserBonus)
-        for user_bonus_map in user_bonus_map_async
-    ]
-
-    result = toloka_client.create_user_bonuses(
-        user_bonuses,
-        operation_id=create_user_bonuses_operation_id,
-    )
-    assert result == UserBonusBatchCreateResult.structure(user_bonuses_result_map)
 
 
 def test_create_user_bonuses_sync_via_async_retry(
@@ -473,12 +395,6 @@ def test_create_user_bonuses_sync_via_async_retry(
     create_user_bonuses_operation_success, create_user_bonuses_log,
     user_bonuses_result_map
 ):
-    def return_user_bonuses(request):
-        return httpx.Response(
-            text=simplejson.dumps({'items': user_bonus_map_async_with_read_only, 'has_more': False}),
-            status_code=200
-        )
-
     user_bonuses = [
         client.structure(user_bonus_map, client.user_bonus.UserBonus)
         for user_bonus_map in user_bonus_map_async
@@ -489,7 +405,7 @@ def test_create_user_bonuses_sync_via_async_retry(
         toloka_url=toloka_url,
         create_method=toloka_client.create_user_bonuses,
         create_method_kwargs={'user_bonuses': user_bonuses},
-        returned_object=return_user_bonuses,
+        returned_object=simplejson.dumps({'items': user_bonus_map_async_with_read_only, 'has_more': False}),
         expected_response_object=UserBonusBatchCreateResult.structure(user_bonuses_result_map),
         success_operation_map=create_user_bonuses_operation_success,
         operation_log=create_user_bonuses_log,
@@ -504,12 +420,6 @@ def test_create_user_bonuses_sync_via_async_retry_failed_operation(
     create_user_bonuses_operation_fail, create_user_bonuses_log,
     user_bonuses_result_map
 ):
-    def return_user_bonuses(request):
-        return httpx.Response(
-            text=simplejson.dumps({'items': user_bonus_map_async_with_read_only, 'has_more': False}),
-            status_code=200
-        )
-
     user_bonuses = [
         client.structure(user_bonus_map, client.user_bonus.UserBonus)
         for user_bonus_map in user_bonus_map_async
@@ -520,11 +430,8 @@ def test_create_user_bonuses_sync_via_async_retry_failed_operation(
         toloka_url=toloka_url,
         create_method=toloka_client.create_user_bonuses,
         create_method_kwargs={'user_bonuses': user_bonuses},
-        get_object_side_effect=return_user_bonuses,
         failed_operation_map=create_user_bonuses_operation_fail,
-        operation_log=create_user_bonuses_log,
         create_object_path='user-bonuses',
-        get_object_path='user-bonuses',
     )
 
 
@@ -532,72 +439,51 @@ def test_create_user_bonuses_async(
     respx_mock, toloka_client, toloka_url, user_bonus_map_async, create_user_bonuses_operation_id,
     create_user_bonus_operation_running
 ):
-
-    def user_bonuses(request):
-        expected_headers = {
-            'X-Caller-Context': 'client' if isinstance(toloka_client, client.TolokaClient) else 'async_client',
-            'X-Top-Level-Method': 'create_user_bonuses_async',
-            'X-Low-Level-Method': 'create_user_bonuses_async',
-        }
-        check_headers(request, expected_headers)
-
-        assert QueryParams(
-            async_mode='true',
-            operation_id=str(create_user_bonuses_operation_id),
-        ) == request.url.params
-        assert user_bonus_map_async == simplejson.loads(request.content)
-        return httpx.Response(text=simplejson.dumps(create_user_bonus_operation_running), status_code=202)
-
-    respx_mock.post(f'{toloka_url}/user-bonuses').mock(side_effect=user_bonuses)
-
-    # Request object syntax
-    result = toloka_client.create_user_bonuses_async(
-        client.structure(user_bonus_map_async, List[client.UserBonus]),
-        client.user_bonus.UserBonusesCreateRequestParameters(operation_id=create_user_bonuses_operation_id),
+    assert_async_object_creation_is_successful(
+        respx_mock=respx_mock,
+        toloka_client=toloka_client,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_user_bonuses_async,
+        create_method_kwargs={
+            'user_bonuses': client.structure(user_bonus_map_async, List[client.UserBonus]),
+            'operation_id': create_user_bonuses_operation_id,
+        },
+        create_object_path='user-bonuses',
+        success_operation_map=create_user_bonus_operation_running,
+        expected_query_params={
+            'async_mode': 'true',
+            'operation_id': str(create_user_bonuses_operation_id),
+        },
+        top_level_method_header='create_user_bonuses_async',
+        low_level_method_header='create_user_bonuses_async',
     )
-    assert create_user_bonus_operation_running == client.unstructure(result)
-
-    # Expanded syntax
-    result = toloka_client.create_user_bonuses_async(
-        client.structure(user_bonus_map_async, List[client.UserBonus]),
-        operation_id=create_user_bonuses_operation_id,
-    )
-    assert create_user_bonus_operation_running == client.unstructure(result)
 
 
 def test_create_user_bonuses_async_retry(
     respx_mock, toloka_client, toloka_url, user_bonus_map_async, create_user_bonus_operation_running
 ):
-    requests_count = 0
-    first_request_op_id = None
+    assert_retried_async_object_creation_returns_existing_operation(
+        respx_mock=respx_mock,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_user_bonuses_async,
+        create_method_kwargs={
+            'user_bonuses': client.structure(user_bonus_map_async, List[client.UserBonus]),
+        },
+        create_object_path='user-bonuses',
+        success_operation_map=create_user_bonus_operation_running,
+    )
 
-    def user_bonuses(request):
-        nonlocal requests_count
-        nonlocal first_request_op_id
 
-        requests_count += 1
-        if requests_count == 1:
-            first_request_op_id = request.url.params['operation_id']
-            return httpx.Response(status_code=500)
-
-        assert request.url.params['operation_id'] == first_request_op_id
-        unstructured_error = client.unstructure(
-            IncorrectActionsApiError(
-                code='OPERATION_ALREADY_EXISTS',
-            )
-        )
-        del unstructured_error['status_code']
-
-        return httpx.Response(
-            json=unstructured_error,
-            status_code=409
-        )
-
-    respx_mock.get(
-        re.compile(rf'{toloka_url}/operations/.*')
-    ).mock(httpx.Response(json=create_user_bonus_operation_running, status_code=200))
-    respx_mock.post(f'{toloka_url}/user-bonuses').mock(side_effect=user_bonuses)
-
-    result = toloka_client.create_user_bonuses_async(client.structure(user_bonus_map_async, List[client.UserBonus]))
-    assert requests_count == 2
-    assert create_user_bonus_operation_running == client.unstructure(result)
+def test_create_user_bonuses_async_retry_failed_operation(
+    respx_mock, toloka_client, toloka_url, user_bonus_map_async, create_user_bonus_operation_fail
+):
+    assert_retried_failed_operation_fails_with_failed_operation_exception(
+        respx_mock=respx_mock,
+        toloka_url=toloka_url,
+        create_method=toloka_client.create_user_bonuses_async,
+        create_method_kwargs={
+            'user_bonuses': client.structure(user_bonus_map_async, List[client.UserBonus]),
+        },
+        failed_operation_map=create_user_bonus_operation_fail,
+        create_object_path='user-bonuses',
+    )


### PR DESCRIPTION
Currently, there is a bug when an attempt to idempotently create an entity will silently fail. This happens when the operation is found failed during a retry attempt.

In this PR:
* Refactored idempotent operations tests to reduce code duplication
* Fixed previously described bug
* Fixed bug when exception representation will not be printed due to an inability to parse erroneous response payload as JSON (now we will fall back to naive string representation)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
