### PR TITLE
Change pipeline observers storage logic to support pickling between iterations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.md') as f:
     readme = f.read()
 
 EXTRAS_REQUIRE = {
-    'dev': ['respx', 'aiohttp', 'pytest', 'pytest-lazy-fixture', 'pytest-asyncio'],
+    'dev': ['respx', 'aiohttp', 'pytest', 'pytest-lazy-fixture', 'pytest-asyncio', 'pytest-mock'],
     'pandas': ['pandas'],
     'autoquality': ['crowd-kit >= 1.0.0'],
     's3': ['boto3 >= 1.4.7'],

--- a/src/streaming/observer.py
+++ b/src/streaming/observer.py
@@ -29,7 +29,10 @@ class BaseObserver:
     _enabled: bool = attr.ib(default=True, init=False)
     _deleted: bool = attr.ib(default=False, init=False)
 
-    def _get_unique_key(self) -> Tuple:
+    def get_unique_key(self) -> Tuple:
+        """This method should return identifier for this observer unique in the current pipeline context.
+        """
+
         return (self.__class__.__name__, self.name or '')
 
     def inject(self, injection: Any) -> None:
@@ -127,8 +130,8 @@ class BasePoolObserver(BaseObserver):
     toloka_client: AsyncInterfaceWrapper[TolokaClientSyncOrAsyncType] = attr.ib(converter=_wrap_client_to_async_converter)
     pool_id: str = attr.ib()
 
-    def _get_unique_key(self) -> Tuple:
-        return super()._get_unique_key() + (self.pool_id,)
+    def get_unique_key(self) -> Tuple:
+        return super().get_unique_key() + (self.pool_id,)
 
     @add_headers('streaming')
     async def should_resume(self) -> bool:
@@ -187,8 +190,8 @@ class PoolStatusObserver(BasePoolObserver):
     _callbacks: Dict[Pool.Status, List[CallbackForPoolAsyncType]] = attr.ib(factory=dict, init=False)
     _previous_status: Optional[Pool.Status] = attr.ib(default=None, init=False)
 
-    def _get_unique_key(self) -> Tuple:
-        return super()._get_unique_key() + tuple(sorted(
+    def get_unique_key(self) -> Tuple:
+        return super().get_unique_key() + tuple(sorted(
             (status.value, _get_callbacks_unique_key(callbacks))
             for status, callbacks in self._callbacks.items()
         ))
@@ -276,7 +279,7 @@ class _CallbacksCursorConsumer:
     cursor: AssignmentCursor = attr.ib()
     callbacks: List[CallbackForAssignmentEventsAsyncType] = attr.ib(factory=list, init=False)
 
-    def _get_unique_key(self) -> Tuple:
+    def get_unique_key(self) -> Tuple:
         return self.cursor._event_type.value, _get_callbacks_unique_key(self.callbacks)
 
     def inject(self, injection: '_CallbacksCursorConsumer') -> None:
@@ -337,19 +340,19 @@ class AssignmentsObserver(BasePoolObserver):
 
     _callbacks: Dict[AssignmentEvent.Type, _CallbacksCursorConsumer] = attr.ib(factory=dict, init=False)
 
-    def _get_unique_key(self) -> Tuple:
-        return super()._get_unique_key() + tuple(sorted(
-            consumer._get_unique_key()
+    def get_unique_key(self) -> Tuple:
+        return super().get_unique_key() + tuple(sorted(
+            consumer.get_unique_key()
             for consumer in self._callbacks.values()
         ))
 
     def inject(self, injection: 'AssignmentsObserver') -> None:
         injection_consumer_by_key = {
-            consumer._get_unique_key(): consumer
+            consumer.get_unique_key(): consumer
             for consumer in injection._callbacks.values()
         }
         for consumer in self._callbacks.values():
-            key = consumer._get_unique_key()
+            key = consumer.get_unique_key()
             consumer.inject(injection_consumer_by_key[key])
 
     # Setup section.

--- a/tests/streaming/test_shutdown.py
+++ b/tests/streaming/test_shutdown.py
@@ -41,7 +41,7 @@ class ObserverToInterrupt:
     async def should_resume(self):
         return self._should_resume
 
-    def _get_unique_key(self):
+    def get_unique_key(self):
         return f'some-uniq-key-for-{type(self).__name__}'
 
     def inject(self, other: 'ObserverToInterrupt') -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ python =
 [testenv]
 deps =
     aiohttp
+    attrs20: attrs==20.3.0
+    attrs21: attrs>=21.2.0
+    dash<=2.8.1
     data-science-types
     filelock >= 3.2.0
     flake8
@@ -22,11 +25,9 @@ deps =
     pytest
     pytest-asyncio
     pytest-lazy-fixture
+    pytest-mock
     respx
     types-urllib3
-    dash<=2.8.1
-    attrs20: attrs==20.3.0
-    attrs21: attrs>=21.2.0
 
 commands =
     all: pytest tests -vv


### PR DESCRIPTION
Pipeline observers' storage logic depended on object ids not preserved during pickling. This led to confusing logging messages (misleading "New observers found in quantity" message) and the inability to delete observers during the pipeline run.
This PR changes storage logic to use observers `get_unique_key()` method instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
