### PR TITLE
Add python 3.11 to the supported versions list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ def get_ipython_with_version():
 
 
 EXTRAS_REQUIRE = {
-    'dev': ['respx', 'aiohttp', 'pytest', 'pytest-lazy-fixture', 'pytest-asyncio', 'pytest-timeout', 'pytest-mock'],
+    'dev': [
+        'respx', 'aiohttp', 'pytest', 'pytest-lazy-fixture', 'pytest-asyncio', 'pytest-timeout', 'pytest-mock', 'tox'
+    ],
     'pandas': ['pandas'],
     'autoquality': ['crowd-kit >= 1.0.0'],
     's3': ['boto3 >= 1.4.7'],
@@ -81,6 +83,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,18 @@ def get_ipython_with_version():
 
 EXTRAS_REQUIRE = {
     'dev': [
-        'respx', 'aiohttp', 'pytest', 'pytest-lazy-fixture', 'pytest-asyncio', 'pytest-timeout', 'pytest-mock', 'tox'
+        'aiohttp',
+        'data-science-types',
+        'flake8',
+        'mypy',
+        'pytest',
+        'pytest-asyncio',
+        'pytest-lazy-fixture',
+        'pytest-mock',
+        'pytest-timeout',
+        'respx',
+        'tox',
+        'types-urllib3',
     ],
     'pandas': ['pandas'],
     'autoquality': ['crowd-kit >= 1.0.0'],

--- a/src/client/primitives/retry.pyi
+++ b/src/client/primitives/retry.pyi
@@ -48,21 +48,6 @@ class TolokaRetry(urllib3.util.retry.Retry):
     _retry_quotas: typing.Union[typing.List[str], str, None]
 
 
-class HTTPXRequestFn(typing_extensions.Protocol):
-    def __call__(
-        self,
-        method: str,
-        url: typing.Union['URL', str],
-        **kwargs
-    ) -> urllib3.response.HTTPResponse: ...
-
-    def __init__(
-        self,
-        *args,
-        **kwargs
-    ): ...
-
-
 class RetryingOverURLLibRetry(tenacity.BaseRetrying, metaclass=abc.ABCMeta):
     """Adapter class that allows usage of the urllib3 Retry class in httpx using the tenacity retrying mechanism.
 
@@ -100,7 +85,7 @@ class RetryingOverURLLibRetry(tenacity.BaseRetrying, metaclass=abc.ABCMeta):
         **kwargs
     ): ...
 
-    def wraps(self, f: HTTPXRequestFn) -> HTTPXRequestFn: ...
+    def wraps(self, f: tenacity.WrappedFn) -> tenacity.WrappedFn: ...
 
     def __getstate__(self): ...
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
     3.8: py38-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.9: py39-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.10: py310-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all
-    3.11: py310-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
+    3.11: py311-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.3.0
 # attrs{20,21} appear due to the issue https://github.com/Toloka/toloka-kit/issues/37
-envlist = py3{7,8,9,10}-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all
+envlist = py3{7,8,9,10,11}-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all
 isolated_build = True
 requires = setuptools >= 36.2.0
 
@@ -11,6 +11,7 @@ python =
     3.8: py38-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.9: py39-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.10: py310-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all
+    3.11: py310-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
 
 [testenv]
 deps =


### PR DESCRIPTION
* Add python 3.11 to the list of supported versions and run tests against it
* Fix stub type problems caused by https://github.com/Toloka/toloka-kit/pull/193