### PR TITLE
Add time lag for cursors

### DIFF
--- a/src/metrics/pool_metrics.py
+++ b/src/metrics/pool_metrics.py
@@ -71,6 +71,8 @@ class AssignmentEventsInPool(BasePoolMetric):
         skipped_name: Metric name for a count of skipped events. Default None.
         expired_name: Metric name for a count of expired events. Default None.
         join_events: Count all events in one point.  Default `False`.
+        cursor_time_lag: Time lag for cursor. This controls time lag between assignments being added and this metric
+            being updated. See BaseCursor.time_lag for details and reasoning behind this.
 
     Raises:
         ValueError: If all metric names are set to None or if there are duplicate metric names.
@@ -97,6 +99,8 @@ class AssignmentEventsInPool(BasePoolMetric):
     _rejected_name: Optional[str] = None
     _skipped_name: Optional[str] = None
     _expired_name: Optional[str] = None
+
+    _cursor_time_lag: datetime.timedelta = cursor.DEFAULT_LAG
 
     _join_events: bool = False
 
@@ -137,6 +141,7 @@ class AssignmentEventsInPool(BasePoolMetric):
                     pool_id=self.pool_id,
                     event_type=status_value,
                     toloka_client=self.atoloka_client,
+                    time_lag=self._cursor_time_lag,
                     **{f'{status_value.lower()}_gte': start_time},
                 )
         return cursors
@@ -453,6 +458,8 @@ class BansInPool(BasePoolMetric):
         count_name: Metric name for a count of bans.
         filter_by_comment: Allow to split Toloker restriction into several lines based on comment.
             Dictionary where, key - comment string, and value - name for line in which will be aggregated bans with this comments.
+        cursor_time_lag: Time lag for cursor. This controls time lag between user restrictions being added and this
+            metric being updated. See BaseCursor.time_lag for details and reasoning behind this.
         join_events: Count all events in one point. Default `False`.
 
     Example:
@@ -491,6 +498,7 @@ class BansInPool(BasePoolMetric):
     """
     _count_name: Optional[str] = None
     _filter_by_comment: Optional[Dict[str, str]] = None  # {'comment': 'line_name'}
+    _cursor_time_lag: datetime.timedelta = cursor.DEFAULT_LAG
 
     _join_events: bool = False
 
@@ -515,7 +523,8 @@ class BansInPool(BasePoolMetric):
         return cursor.UserRestrictionCursor(
             toloka_client=self.atoloka_client,
             created_gte=datetime.datetime.now(datetime.timezone.utc),
-            pool_id=self.pool_id
+            pool_id=self.pool_id,
+            time_lag=self._cursor_time_lag,
         )
 
     async def _get_lines_impl(self) -> Dict[str, List[Tuple[Any, Any]]]:

--- a/src/streaming/cursor.py
+++ b/src/streaming/cursor.py
@@ -172,6 +172,11 @@ class BaseCursor:
                 if not response.has_more:
                     return
 
+                # Multiple items can have the same time field value. If items with the same time field value are split
+                # between responses due to the fetcher limit they will be fetched twice and filtered by _seen_ids field
+                # afterwards. But there is a corner case when all items in the response have the same time field value.
+                # As the result we will fetch the same items over and over again. To avoid this we need fall back to
+                # iteration over id field.
                 if self._get_time(response.items[0]) == max_time:
                     fixed_time_request = attr.evolve(self._request, **{self._time_field_lte: max_time})
                     for item in _ByIdCursor(fetcher, fixed_time_request):  # Diff between sync and async.
@@ -201,6 +206,11 @@ class BaseCursor:
                 if not response.has_more:
                     return
 
+                # Multiple items can have the same time field value. If items with the same time field value are split
+                # between responses due to the fetcher limit they will be fetched twice and filtered by _seen_ids field
+                # afterwards. But there is a corner case when all items in the response have the same time field value.
+                # As the result we will fetch the same items over and over again. To avoid this we need fall back to
+                # iteration over id field.
                 if self._get_time(response.items[0]) == max_time:
                     fixed_time_request = attr.evolve(self._request, **{self._time_field_lte: max_time})
                     async for item in _ByIdCursor(fetcher, fixed_time_request):  # Diff between sync and async.

--- a/src/util/_codegen.py
+++ b/src/util/_codegen.py
@@ -4,6 +4,8 @@ __all__: list = [
     'universal_decorator',
     'expand'
 ]
+
+import datetime
 import functools
 import inspect
 import linecache
@@ -253,7 +255,12 @@ def expand_func_by_argument(func: Callable, arg_name: str, arg_type: Optional[Ty
         func_sig.replace(parameters=new_params),
         function_body,
         inspect.iscoroutinefunction(func),
-        {arg_type.__name__: arg_type, 'func': func, 'NOTHING': attr.NOTHING}
+        {
+            arg_type.__name__: arg_type,
+            'func': func,
+            'NOTHING': attr.NOTHING,
+            'datetime': datetime,
+        }
     )
     expanded_func.__doc__ = func.__doc__
     return expanded_func

--- a/tests/streaming/test_cursor.py
+++ b/tests/streaming/test_cursor.py
@@ -307,6 +307,7 @@ class MockEvent(BaseEvent):
 
 class MockSearchRequest(BaseSearchRequest):
     class CompareFields:
+        id: str
         mock_time_field: datetime
 
 
@@ -337,6 +338,8 @@ class MockCursor(BaseCursor):
                 filtered_items = [
                     item for item in filtered_items if item.mock_time_field <= request.mock_time_field_lte
                 ]
+            if request.id_gt:
+                filtered_items = [item for item in filtered_items if int(item.id) > int(request.id_gt)]
             return MockResponse(
                 items=filtered_items[:self.batch_limit], has_more=len(filtered_items) > self.batch_limit
             )
@@ -360,8 +363,9 @@ class MockCursor(BaseCursor):
         ],
         # time collision
         [
-            [MockItem(id=str(i), mock_time_field=datetime(2020, 1, 1, 0, 0, 0)) for i in range(2)]
-            + [MockItem(id='2', mock_time_field=datetime(2020, 1, 1, 0, 0, 1))],
+            [MockItem(id=str(i), mock_time_field=datetime(2020, 1, 1, 0, 0, 0)) for i in range(3)],
+            [MockItem(id=str(i), mock_time_field=datetime(2020, 1, 1, 0, 0, 0)) for i in range(4, 6)]
+            + [MockItem(id='6', mock_time_field=datetime(2020, 1, 1, 0, 0, 1))],
             [MockItem(id='3', mock_time_field=datetime(2020, 1, 1, 0, 0, 0))]
         ]
     ]

--- a/tests/testutils/backend_mock.py
+++ b/tests/testutils/backend_mock.py
@@ -47,7 +47,7 @@ class ConditionInterval:
 
 @attr.s
 class BackendSearchMock:
-    """Use in requests mock to imitage Toloka backend search methods.
+    """Use in requests mock to imitate Toloka backend search methods.
 
     Attributes:
         storage: List of items. Imitates DB.


### PR DESCRIPTION
This PR introduces a configurable time lag before events can be seen by the streaming cursors and sets the lag default value to 1 minute for all cursors.

This change is required to fix a bug when streaming pipelines can miss events in some rare cases due to the lack of strong consistency in the Toloka API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
