### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -45,7 +45,6 @@ body:
       description: What is your python version? If it's not in the list that it's not supported by Toloka-Kit.
       multiple: false
       options:
-        - 3.7
         - 3.8
         - 3.9
         - 3.10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The API allows you to build scalable and fully automated human-in-the-loop ML pi
 ## Prerequisites
 
 Before you begin, make sure that:
-* You are using [Python](https://www.python.org/) v3.7 or higher.
+* You are using [Python](https://www.python.org/) v3.8 or higher.
 * You are [registered](https://toloka.ai/docs/guide/access/?utm_source=github&utm_medium=site&utm_campaign=tolokakit) in Toloka as a requester.
 * You have [topped up](https://toloka.ai/docs/guide/refill/?utm_source=github&utm_medium=site&utm_campaign=tolokakit) your Toloka account.
 * You have [set up an OAuth token](https://toloka.ai/docs/api/api-reference/?utm_source=github&utm_medium=site&utm_campaign=tolokakit#overview--accessing-the-api) to access Toloka API.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     license=about['__license__'],
     author='Vladimir Losev',
     author_email='losev@yandex-team.ru',
-    python_requires='>=3.7.0',
+    python_requires='>=3.8.0',
     install_requires=[
         'attrs >= 20.3.0',
         'cattrs >= 1.9',
@@ -90,7 +90,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 minversion = 3.3.0
 # attrs{20,21} appear due to the issue https://github.com/Toloka/toloka-kit/issues/37
-envlist = py3{7,8,9,10,11}-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all
+envlist = py3{8,9,10,11}-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all
 isolated_build = True
 requires = setuptools >= 36.2.0
 
 [gh-actions]
 python =
-    3.7: py37-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.8: py38-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.9: py39-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics}
     3.10: py310-attrs{20,21}-{all,pandas,autoquality,zookeeper,jupyter-metrics},py310-stubgeneration-all


### PR DESCRIPTION
Python 3.7 has reached EOL and will not get security updates anymore ([see](https://www.python.org/downloads/release/python-3717/)). Toloka-Kit no longer supports this version.