### PR TITLE
Add example for language filter and link to recipe

### DIFF
--- a/docs/en/_includes/toloka-kit-toc.yaml
+++ b/docs/en/_includes/toloka-kit-toc.yaml
@@ -45,6 +45,8 @@ items:
             href: ../toloka-kit/recipes/set-overlap.md
           - name: Filter Tolokers
             href: ../toloka-kit/recipes/filter-tolokers.md
+          - name: Filter Tolokers with confirmed language knowledge
+            href: ../toloka-kit/recipes/filter-tolokers-languages.md
           - name: Use quality control rules
             href: ../toloka-kit/recipes/use-quality-control-rules.md
       - name: Skills
@@ -95,6 +97,14 @@ items:
           href: ../toloka-kit/recipes/get-rewards.md
         - name: Get bonus details
           href: ../toloka-kit/recipes/get-reward-by-id.md
+      - name: Banning Tolokers
+        items:
+        - name: Ban Tolokers
+          href: ../toloka-kit/recipes/ban-tolokers.md
+        - name: Get list of bans
+          href: ../toloka-kit/recipes/get-restrictions.md
+        - name: Remove ban from Toloker
+          href: ../toloka-kit/recipes/delete-restriction.md
       - name: Messages
         items:
         - name: Send messages

--- a/src/client/filter.py
+++ b/src/client/filter.py
@@ -374,6 +374,18 @@ class Languages(Profile, InclusionConditionMixin, spec_value=Profile.Key.LANGUAG
         verified: If set to `True`, only Tolokers who have passed a language test are selected.
             Tests are available for languages: `AR`, `DE`, `EN`, `ES`, `FR`,
             `HE`, `ID`, `JA`, `PT`, `RU`, `SV`, `ZH-HANS`.
+
+    Example:
+
+        >>> from toloka.client.primitives.operators import InclusionOperator
+        >>>
+        >>> updated_pool = toloka_client.get_pool('38955320')
+        >>> updated_pool.filter=(
+        >>>     (toloka.filter.Languages(operator=InclusionOperator.IN, value=['EN', 'DE'], verified=True)) &
+        >>>     (toloka.filter.Languages(operator=InclusionOperator.IN, value=['FR'], verified=True))
+        >>> )
+        >>> toloka_client.update_pool(pool_id=updated_pool.id, pool=updated_pool)
+        ...
     """
 
     VERIFIED_LANGUAGES_TO_SKILLS: ClassVar[Dict[str, str]] = {


### PR DESCRIPTION
## Description

Added an example for languages filter (https://st.yandex-team.ru/TOLOKADOC-350) and updated the menu

### Connected issues (if any)

[TOLOKADOC-350](https://st.yandex-team.ru/TOLOKADOC-350)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
