### PR TITLE
Update create_app_items to return created item ids

### DIFF
--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -4171,7 +4171,7 @@ class TolokaClient:
 
     @expand('request')
     @add_headers('client')
-    def create_app_items(self, app_project_id: str, request: AppItemsCreateRequest):
+    def create_app_items(self, app_project_id: str, request: AppItemsCreateRequest) -> List[str]:
         """Creates task items in an App project in Toloka and adds them to an existing batch.
 
         Example:
@@ -4191,13 +4191,15 @@ class TolokaClient:
         Args:
             app_project_id: The ID of the App project.
             request: The request parameters.
+        Returns:
+            List[str]: The IDs of created app items.
         """
 
         if self.url != self.Environment.PRODUCTION.value:
             raise RuntimeError('this method supports only production environment')
 
-        self._raw_request('post', f'/app/v0/app-projects/{app_project_id}/items/bulk', json=unstructure(request))
-        return
+        response = self._request('post', f'/app/v0/app-projects/{app_project_id}/items/bulk', json=unstructure(request))
+        return structure(response, List[str])
 
     @add_headers('client')
     def get_app_item(self, app_project_id: str, app_item_id: str) -> AppItem:

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -468,7 +468,7 @@ def test_create_app_item(respx_mock, toloka_client_prod, toloka_app_url, app_ite
 
 
 def test_create_app_items(respx_mock, toloka_client_prod, toloka_app_url, app_item_map, app_item_map_with_readonly):
-
+    expected_app_item_ids = ['created-app-item-id']
     app_items_create_request = {
         'batch_id': app_item_map['batch_id'],
         'items': [app_item_map['input_data']]
@@ -483,11 +483,12 @@ def test_create_app_items(respx_mock, toloka_client_prod, toloka_app_url, app_it
         check_headers(request, expected_headers)
 
         assert app_items_create_request == simplejson.loads(request.content)
-        return httpx.Response(status_code=201)
+        return httpx.Response(status_code=201, json=expected_app_item_ids)
 
     respx_mock.post(f'{toloka_app_url}/app-projects/123/items/bulk').mock(side_effect=app_items)
     app_item = client.structure(app_items_create_request, client.app.AppItemsCreateRequest)
-    toloka_client_prod.create_app_items('123', app_item)
+    app_item_ids = toloka_client_prod.create_app_items('123', app_item)
+    assert app_item_ids == app_item_ids
 
 
 def test_find_app_batches(respx_mock, toloka_client_prod, toloka_app_url, app_batch_map):


### PR DESCRIPTION
Apps API now returns list of created items for `/app-projects/{app_project_id}/items/bulk`